### PR TITLE
When on real hardware, create a logfile

### DIFF
--- a/main.c
+++ b/main.c
@@ -80,6 +80,8 @@ void main(void){
 
     print("Kernel Test Suite");
 
+    open_output_file("kernel_tests.log");
+
     if(load_conf_file() == 0){
         print("Config File Loaded");
         print("is_emu: %d", is_emu);
@@ -101,6 +103,7 @@ void main(void){
     XSleep(10000);
 
     vector_free(&tests_to_run);
+    close_output_file();
 
     pb_kill();
     XReboot();

--- a/output.c
+++ b/output.c
@@ -1,7 +1,15 @@
 #include <pbkit/pbkit.h>
 #include <xboxrt/debug.h>
+#include <hal/fileio.h>
+
 #include <stdarg.h>
 #include <stdlib.h>
+#include <string.h>
+
+#include "global.h"
+#include "output.h"
+
+static int output_filehandle = 0;
 
 void print(char* str, ...){
     va_list args;
@@ -17,6 +25,13 @@ void print(char* str, ...){
     /*** PRINT ON CONSOLE (CXBX) ***/
     DbgPrint("%s\n", buffer);
     /*******************************/
+
+    // Write information to logfile
+    strcat(buffer, "\n");
+    write_to_output_file(
+        buffer,
+        strlen(buffer)
+    );
 }
 
 void print_test_header(const char* func_num, const char* func_name) {
@@ -32,4 +47,59 @@ void print_test_footer(
     else {
         print("%s - %s: One or more tests FAILED", func_num, func_name);
     }
+}
+
+int open_output_file(char* file_name) {
+    if(is_emu) {
+        print("Skipping creating %s because on emulator", file_name);
+        return 0;
+    }
+
+    debugPrint("Creating file %s", file_name);
+    int ret = XCreateFile(
+        &output_filehandle,
+        file_name,
+        GENERIC_WRITE,
+        FILE_SHARE_WRITE,
+        CREATE_ALWAYS,
+        FILE_ATTRIBUTE_NORMAL
+    );
+    if(ret != 0) {
+        debugPrint("ERROR: Could not create file %s", file_name);
+    }
+    return ret;
+}
+
+int write_to_output_file(void* data_to_print, unsigned int num_bytes_to_print) {
+    if(is_emu) {
+        return 0;
+    }
+
+    unsigned int bytes_written;
+    int ret = XWriteFile(
+        output_filehandle,
+        data_to_print,
+        num_bytes_to_print,
+        &bytes_written
+    );
+    if(!ret) {
+        debugPrint("ERROR: Could not write to output file");
+    }
+    if(bytes_written != num_bytes_to_print) {
+        debugPrint("ERROR: Bytes written = %u, bytes expected to write = %u",
+                   bytes_written, num_bytes_to_print);
+        ret = 1;
+    }
+    return ret;
+}
+
+int close_output_file() {
+    if(is_emu) {
+        return 0;
+    }
+    int ret = XCloseHandle(output_filehandle);
+    if(!ret) {
+        debugPrint("ERROR: Could not close output file");
+    }
+    return ret;
 }

--- a/output.h
+++ b/output.h
@@ -7,4 +7,10 @@ void print(char* str, ...);
 void print_test_header(const char*, const char*);
 void print_test_footer(const char*, const char*, BOOL);
 
+// Real hardware can only display one screen of text at a time. Create an output
+// logfile to contain information for all tests.
+int open_output_file(char*);
+int write_to_output_file(void*, unsigned int);
+int close_output_file();
+
 #endif


### PR DESCRIPTION
On real hardware, only one screen of text is shown at a time. If more than one screens worth of text is printed, then the previous screen is erased, and the new lines are printed on the blank screen. This is not desirable when running a large number of tests. Also, trying to read the text on the console is hard, so being able to look at a logfile back on the computer is nice.

This adds a hook to the print function that also prints the information to a logfile when on the real hardware only. Cxbx-Reloaded does not need since print can be redirected to a kernel.log file already. A logfile named "kernel_test.log" is created in the same directory as the .xbe which can be FTP'd back to your computer for examination.