### PR TITLE
Create macros for assertion functions

### DIFF
--- a/assertion_defines.h
+++ b/assertion_defines.h
@@ -1,0 +1,26 @@
+#ifndef ASSERTION_DEFINES_H
+#define ASSERTION_DEFINES_H
+
+#include "output.h"
+
+#define ASSERT_HEADER BOOL test_passed = 1;
+
+#define ASSERT_FOOTER(test_name) \
+    if(test_passed) { \
+        print("  Test '%s' PASSED", test_name); \
+    } \
+    else { \
+        print("  Test '%s' FAILED", test_name); \
+    } \
+    return test_passed;
+
+#define GEN_CHECK(check_var, expected_var, varname) \
+    if(check_var != expected_var) { \
+        print( \
+            "  Expected %s = 0x%x, Got %s = 0x%x", \
+            varname, expected_var, varname, check_var \
+        ); \
+        test_passed = 0; \
+    }
+
+#endif // ASSERTION_DEFINES_H

--- a/ke_assertions.c
+++ b/ke_assertions.c
@@ -1,0 +1,14 @@
+#include "ke_assertions.h"
+#include "assertion_defines.h"
+
+BOOL assert_critical_region(
+    PKTHREAD thread,
+    ULONG expected_Apc,
+    const char* test_name
+) {
+    ASSERT_HEADER
+
+    GEN_CHECK(thread->KernelApcDisable, expected_Apc, "KernelApcDisable")
+
+    ASSERT_FOOTER(test_name)
+}

--- a/ke_assertions.h
+++ b/ke_assertions.h
@@ -1,0 +1,8 @@
+#ifndef KE_ASSERTIONS_H
+#define KE_ASSERTIONS_H
+
+#include <xboxkrnl/xboxkrnl.h>
+
+BOOL assert_critical_region(PKTHREAD, ULONG, const char*);
+
+#endif // KE_ASSERTIONS_H

--- a/ke_tests.c
+++ b/ke_tests.c
@@ -1,28 +1,7 @@
 #include <xboxkrnl/xboxkrnl.h>
 
+#include "ke_assertions.h"
 #include "output.h"
-
-static BOOL assert_critical_region(
-    PKTHREAD thread, 
-    ULONG expected_Apc,
-    const char* test_name
-) {
-    BOOL test_passed = 1;
-    if(thread->KernelApcDisable != expected_Apc) {
-        print(
-            "Expected KernelApcDisable = 0x%x, Got KernelApcDisable = 0x%x",
-            thread->KernelApcDisable, expected_Apc
-        );
-        test_passed = 0;
-    }
-    if(test_passed) {
-        print("Test '%s' PASSED", test_name);
-    }
-    else {
-        print("Test '%s' FAILED", test_name);
-    }
-    return test_passed;
-}
 
 void test_KeAlertResumeThread(){
     /* FIXME: This is a stub! implement this function! */
@@ -173,7 +152,7 @@ void test_KeLeaveCriticalRegion(){
     tests_passed &= assert_critical_region(thread, -1, "Leave critical region after entering twice");
 
     KeLeaveCriticalRegion();
-    tests_passed &= assert_critical_region(thread, 0, "Leave critical region twice");
+    tests_passed &= assert_critical_region(thread, 0, "Leave critical region again");
 
     print_test_footer(func_num, func_name, tests_passed);
 }

--- a/rtl_assertions.c
+++ b/rtl_assertions.c
@@ -1,0 +1,34 @@
+#include "rtl_assertions.h"
+#include "assertion_defines.h"
+
+BOOL assert_critical_section_equals(
+    PRTL_CRITICAL_SECTION crit_section,
+    LONG expected_LockCount,
+    LONG expected_RecursionCount,
+    HANDLE expected_OwningThread,
+    const char* test_name
+) {
+    ASSERT_HEADER
+
+    GEN_CHECK(crit_section->LockCount, expected_LockCount, "LockCount")
+    GEN_CHECK(crit_section->RecursionCount, expected_RecursionCount, "RecursionCount")
+    GEN_CHECK(crit_section->OwningThread, expected_OwningThread, "OwningThread")
+
+    ASSERT_FOOTER(test_name)
+}
+
+static BOOL assert_ansi_string(
+    PANSI_STRING string,
+    USHORT expected_Length,
+    USHORT expected_MaximumLength,
+    PCHAR expected_Buffer,
+    const char* test_name
+) {
+    ASSERT_HEADER
+
+    GEN_CHECK(string->Length, expected_Length, "Length");
+    GEN_CHECK(string->MaximumLength, expected_MaximumLength, "MaximumLength");
+    GEN_CHECK(string->Buffer, expected_Buffer, "Buffer");
+
+    ASSERT_FOOTER(test_name)
+}

--- a/rtl_assertions.h
+++ b/rtl_assertions.h
@@ -1,0 +1,22 @@
+#ifndef RTL_ASSERTIONS_H
+#define RTL_ASSERTIONS_H
+
+#include <xboxkrnl/xboxkrnl.h>
+
+BOOL assert_critical_section_equals(
+    PRTL_CRITICAL_SECTION,
+    LONG,
+    LONG,
+    HANDLE,
+    const char*
+);
+
+BOOL assert_ansi_string(
+    PANSI_STRING,
+    USHORT,
+    USHORT,
+    PCHAR,
+    const char*
+);
+
+#endif // RTL_ASSERTIONS_H

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -1,46 +1,8 @@
-#include <pbkit/pbkit.h>
+#include <xboxkrnl/xboxkrnl.h>
 #include <string.h>
 
 #include "output.h"
-
-static BOOL assert_critical_section_equals(
-    PRTL_CRITICAL_SECTION crit_section,
-    LONG expected_LockCount,
-    LONG expected_RecursionCount,
-    HANDLE expected_OwningThread,
-    const char* test_name
-)
-{
-    BOOL test_passed = 1;
-    if(crit_section->LockCount != expected_LockCount) {
-        print(
-            "Expected LockCount = 0x%x, Got LockCount = 0x%x",
-            expected_LockCount, crit_section->LockCount
-        );
-        test_passed = 0;
-    }
-    if(crit_section->RecursionCount != expected_RecursionCount) {
-        print(
-            "Expected RecursionCount = 0x%x, Got RecursionCount = 0x%x",
-            expected_RecursionCount, crit_section->RecursionCount
-        );
-        test_passed = 0;
-    }
-    if(crit_section->OwningThread != expected_OwningThread) {
-        print(
-            "Expected OwningThread = 0x%x, Got OwningThread = 0x%x",
-            expected_OwningThread, crit_section->OwningThread
-        );
-        test_passed = 0;
-    }
-    if(test_passed) {
-        print("Test '%s' PASSED", test_name);
-    }
-    else {
-        print("Test '%s' FAILED", test_name);
-    }
-    return test_passed;
-}
+#include "rtl_assertions.h"
 
 void test_RtlAnsiStringToUnicodeString(){
     /* FIXME: This is a stub! implement this function! */
@@ -133,13 +95,11 @@ void test_RtlEnterCriticalSection(){
         1,
         2,
         (HANDLE)KeGetCurrentThread(),
-        "Enter the critical section twice"
+        "Enter the critical section again"
     );
 
-    // Leave three times
     RtlLeaveCriticalSection(&crit_section);
     RtlLeaveCriticalSection(&crit_section);
-
     RtlEnterCriticalSection(&crit_section);
     tests_passed &= assert_critical_section_equals(
         &crit_section,
@@ -266,7 +226,7 @@ void test_RtlLeaveCriticalSection(){
         -1,
         0,
         NULL,
-        "Leave critical section twice"
+        "Leave critical section again"
     );
 
     RtlEnterCriticalSection(&crit_section);


### PR DESCRIPTION
As I was making more tests, I realized I was copy/pasting a lot, so I decided to make macros for creating assertion functions. I also moved the assertion functions out of the test.c files to remove clutter as it is possible to have a large number of assertions in a single kernel function type. Finally, I refactored some of the test name strings to be more clear.