### PR TITLE
Open config.txt on real hardware and allow to only define is_emu in config.txt

### DIFF
--- a/global.c
+++ b/global.c
@@ -1,4 +1,6 @@
 #include "vector.h"
 
-int is_emu = 0;
-vector tests_to_run = {};
+// Until the config.txt file can be loaded on the emulator, set emu by default
+// and use the config.txt file to disable the flag on real hardware
+int is_emu = 1;
+vector tests_to_run;

--- a/output.c
+++ b/output.c
@@ -51,7 +51,7 @@ void print_test_footer(
 
 int open_output_file(char* file_name) {
     if(is_emu) {
-        print("Skipping creating %s because on emulator", file_name);
+        print("Kernel Test Suite: Skipping creating %s because on emulator", file_name);
         return 0;
     }
 


### PR DESCRIPTION
First, the function that was being used to find the config.txt file was returning an empty string. That functionality will need to be fixed later. However, on real hardware, it is possible to open a file in the same directory as the .xbe by just opening 'config.txt'. This will work on real hardware only, so is_emu=1 is set by default. To run on real hardware, a config.txt file must be supplied which sets is_emu=0.

Second, it was not possible to only specify an is_emu value in the config.txt file. If only the is_emu value is supplied, the test suite will run all tests.