### PR TITLE
More Rtl tests

### DIFF
--- a/av_tests.c
+++ b/av_tests.c
@@ -4,34 +4,35 @@
 
 
 void test_AvGetSavedDataAddress(){
-    if(!is_emu){
+/*    if(!is_emu){
          print("0x0001 - AvGetSavedDataAddress: Skipped (due to real hadrware) / value: %x",AvGetSavedDataAddress());
          return;
     }
     AvSetSavedDataAddress((void*) 0x12345678);
     AvGetSavedDataAddress()==(void*)0x12345678 ? print("0x0001 - AvGetSavedDataAddress: Good") : print("0x0001 - AvGetSavedDataAddress: Faulty");
+    */
 }
 
 void test_AvSendTVEncoderOption(){
     /* FIXME: there are other functions such as AV_OPTION_QUERY_MODE, AV_QUERY_ENCODER_TYPE, AV_OPTION_WIDESCREEN etc*/
-    unsigned long res = 0;
+    /*unsigned long res = 0;
     AvSendTVEncoderOption(NULL, 6, 0, &res);
-    print("0x0002 - AvSendTVEncoderOption: %d (0=AV_PACK_NONE 1=AV_PACK_STANDARD 2=AV_PACK_RFU 3=AV_PACK_SCART 4=AV_PACK_HDTV 5=AV_PACK_VGA 6=AV_PACK_SVIDEO)", res);
+    print("0x0002 - AvSendTVEncoderOption: %d (0=AV_PACK_NONE 1=AV_PACK_STANDARD 2=AV_PACK_RFU 3=AV_PACK_SCART 4=AV_PACK_HDTV 5=AV_PACK_VGA 6=AV_PACK_SVIDEO)", res);*/
 }
 
 void test_AvSetDisplayMode(){
-    if(!is_emu){
+    /*if(!is_emu){
          print("0x0003 - AvSetDisplayMode: Skipped (due to real hadrware)");
          return;
     }
-    AvSetDisplayMode(NULL, 0, 0, 0, 0, 0) == 0L ? print("0x0003 - AvSetDisplayMode: 0 (Good)") : print("0x0003 - AvSetDisplayMode: !=0 (Faulty)");
+    AvSetDisplayMode(NULL, 0, 0, 0, 0, 0) == 0L ? print("0x0003 - AvSetDisplayMode: 0 (Good)") : print("0x0003 - AvSetDisplayMode: !=0 (Faulty)");*/
 }
 
 void test_AvSetSavedDataAddress(){
-    if(!is_emu){
+/*    if(!is_emu){
          print("0x0004 - AvSetSavedDataAddress: Skipped (due to real hadrware)");
          return;
     }
     AvSetSavedDataAddress((void*) 0x12345678);
-    AvGetSavedDataAddress()==(void*)0x12345678 ? print("0x0004 - AvSetSavedDataAddress: Good") : print("0x0004 - AvSetSavedDataAddress: Faulty");
+    AvGetSavedDataAddress()==(void*)0x12345678 ? print("0x0004 - AvSetSavedDataAddress: Good") : print("0x0004 - AvSetSavedDataAddress: Faulty");*/
 }

--- a/av_tests.c
+++ b/av_tests.c
@@ -21,7 +21,7 @@ void test_AvSendTVEncoderOption(){
 }
 
 void test_AvSetDisplayMode(){
-    /*if(!is_emu){
+    if(!is_emu){
          print("0x0003 - AvSetDisplayMode: Skipped (due to real hadrware)");
          return;
     }

--- a/rtl_assertions.c
+++ b/rtl_assertions.c
@@ -32,3 +32,19 @@ static BOOL assert_ansi_string(
 
     ASSERT_FOOTER(test_name)
 }
+
+static BOOL assert_unicode_string(
+    PUNICODE_STRING string,
+    USHORT expected_Length,
+    USHORT expected_MaximumLength,
+    PWSTR expected_Buffer,
+    const char* test_name
+) {
+    ASSERT_HEADER
+
+    GEN_CHECK(string->Length, expected_Length, "Length");
+    GEN_CHECK(string->MaximumLength, expected_MaximumLength, "MaximumLength");
+    GEN_CHECK(string->Buffer, expected_Buffer, "Buffer");
+
+    ASSERT_FOOTER(test_name)
+}

--- a/rtl_assertions.h
+++ b/rtl_assertions.h
@@ -19,4 +19,12 @@ BOOL assert_ansi_string(
     const char*
 );
 
+BOOL assert_unicode_string(
+    PUNICODE_STRING,
+    USHORT,
+    USHORT,
+    PWSTR,
+    const char*
+);
+
 #endif // RTL_ASSERTIONS_H

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -33,7 +33,88 @@ void test_RtlCaptureStackBackTrace(){
 }
 
 void test_RtlCharToInteger(){
-    /* FIXME: This is a stub! implement this function! */
+    const char* func_num = "0x010B";
+    const char* func_name = "RtlCharToInteger";
+    BOOL tests_passed = 1;
+    print_test_header(func_num, func_name);
+
+    unsigned long val = 0;
+    NTSTATUS res;
+
+    res = RtlCharToInteger("-1", 0, &val);
+    if(res == STATUS_SUCCESS && val == -1)
+        tests_passed &= 1;
+    else
+        tests_passed = 0;
+
+    res = RtlCharToInteger("0", 0, &val);
+    if(res == STATUS_SUCCESS && val == 0)
+        tests_passed &= 1;
+    else
+        tests_passed = 0;
+
+    res = RtlCharToInteger("1", 0, &val);
+    if(res == STATUS_SUCCESS && val == 1)
+        tests_passed &= 1;
+    else
+        tests_passed = 0;
+
+    res = RtlCharToInteger("0x12345", 0, &val);
+    if(res == STATUS_SUCCESS && val == 0x12345)
+        tests_passed &= 1;
+    else
+        tests_passed = 0;
+
+    res = RtlCharToInteger("1011101100", 2, &val);
+    if(res == STATUS_SUCCESS && val == 748)
+        tests_passed &= 1;
+    else
+        tests_passed = 0;
+
+    res = RtlCharToInteger("-1011101100", 2, &val);
+    if(res == STATUS_SUCCESS && val == -748)
+        tests_passed &= 1;
+    else
+        tests_passed = 0;
+
+    res = RtlCharToInteger("1011101100", 8, &val);
+    if(res == STATUS_SUCCESS && val == 136610368)
+        tests_passed &= 1;
+    else
+        tests_passed = 0;
+
+    res = RtlCharToInteger("-1011101100", 8, &val);
+    if(res == STATUS_SUCCESS && val == -136610368)
+        tests_passed &= 1;
+    else
+        tests_passed = 0;
+
+    res = RtlCharToInteger("1011101100", 10, &val);
+    if(res == STATUS_SUCCESS && val == 1011101100)
+        tests_passed &= 1;
+    else
+        tests_passed = 0;
+
+    res = RtlCharToInteger("-1011101100", 10, &val);
+    if(res == STATUS_SUCCESS && val == -1011101100)
+        tests_passed &= 1;
+    else
+        tests_passed = 0;
+
+    res = RtlCharToInteger("1011101100", 16, &val);
+    if(res == STATUS_SUCCESS && val == 286265600)
+        tests_passed &= 1;
+    else
+        tests_passed = 0;
+
+    res = RtlCharToInteger("0", 20, &val);
+    if(res == STATUS_INVALID_PARAMETER)
+        tests_passed &= 1;
+    else
+        tests_passed = 0;
+
+
+    print_test_footer(func_num, func_name, tests_passed);
 }
 
 void test_RtlCompareMemory(){
@@ -96,7 +177,24 @@ void test_RtlCompareUnicodeString(){
 }
 
 void test_RtlCopyString(){
-    /* FIXME: This is a stub! implement this function! */
+    const char* func_num = "0x0110";
+    const char* func_name = "RtlCopyString";
+    BOOL tests_passed = 1;
+    print_test_header(func_num, func_name);
+
+    char src_char_arr[] = "xbox is cool";
+    char dst_char_arr[] = "            ";
+    STRING src_str;
+    STRING dst_str;
+
+    RtlInitAnsiString(&src_str, src_char_arr);
+    RtlInitAnsiString(&dst_str, dst_char_arr);
+    RtlCopyString(&dst_str, &src_str);
+
+    if(strncmp(src_str.Buffer, dst_char_arr, src_str.Length) != 0)
+        tests_passed = 0;
+
+    print_test_footer(func_num, func_name, tests_passed);
 }
 
 void test_RtlCopyUnicodeString(){
@@ -159,12 +257,52 @@ void test_RtlEnterCriticalSectionAndRegion(){
     /* FIXME: This is a stub! implement this function! */
 }
 
-void test_RtlEqualString(){
-    /* FIXME: This is a stub! implement this function! */
+void test_RtlEqualString(){ // FIXME this test failed on real hardware!!!
+    /*const char* func_num = "0x0117";
+    const char* func_name = "RtlEqualString";
+    BOOL tests_passed = 1;
+    print_test_header(func_num, func_name);
+
+    ANSI_STRING str1;
+    ANSI_STRING str2;
+    ANSI_STRING str3;
+
+    RtlInitAnsiString(&str1, "xbox is cool");
+    RtlInitAnsiString(&str2, "XBOX IS COOL");
+    RtlInitAnsiString(&str3, "is xbox cool?");
+
+    tests_passed &= !RtlEqualString(&str1, &str2, 0);
+    print("1st result=%d", RtlEqualString(&str1, &str2, 0));
+    tests_passed &= RtlEqualString(&str1, &str2, 1);
+    print("2nd result=%d", RtlEqualString(&str1, &str2, 1));
+    tests_passed &= !RtlEqualString(&str1, &str3, 1);
+    print("3rd result=%d", RtlEqualString(&str1, &str3, 1));
+    tests_passed &= !RtlEqualString(&str1, &str3, 0);
+    print("4th result=%d", RtlEqualString(&str1, &str3, 0));
+
+    print_test_footer(func_num, func_name, tests_passed);*/
 }
 
 void test_RtlEqualUnicodeString(){
-    /* FIXME: This is a stub! implement this function! */
+    const char* func_num = "0x0118";
+    const char* func_name = "RtlEqualUnicodeString";
+    BOOL tests_passed = 1;
+    print_test_header(func_num, func_name);
+
+    UNICODE_STRING str1;
+    UNICODE_STRING str2;
+    UNICODE_STRING str3;
+
+    RtlInitUnicodeString(&str1, L"xbox is cool");
+    RtlInitUnicodeString(&str2, L"XBOX IS COOL");
+    RtlInitUnicodeString(&str3, L"is xbox cool?");
+
+    tests_passed &= !RtlEqualUnicodeString(&str1, &str2, 0);
+    tests_passed &= RtlEqualUnicodeString(&str1, &str2, 1);
+    tests_passed &= !RtlEqualUnicodeString(&str1, &str3, 1);
+    tests_passed &= !RtlEqualUnicodeString(&str1, &str3, 0);
+
+    print_test_footer(func_num, func_name, tests_passed);
 }
 
 void test_RtlExtendedIntegerMultiply(){
@@ -191,7 +329,6 @@ void test_RtlFreeAnsiString(){
     const char* func_num = "0x011E";
     const char* func_name = "RtlFreeAnsiString";
     BOOL tests_passed = 1;
-
     print_test_header(func_num, func_name);
 
     const BOOL alloc_buffer = 1;
@@ -214,7 +351,28 @@ void test_RtlFreeAnsiString(){
 }
 
 void test_RtlFreeUnicodeString(){
-    /* FIXME: This is a stub! implement this function! */
+    const char* func_num = "0x011F";
+    const char* func_name = "RtlFreeUnicodeString";
+    BOOL tests_passed = 1;
+    print_test_header(func_num, func_name);
+
+    const BOOL alloc_buffer = 1;
+    ANSI_STRING ansi_string;
+    UNICODE_STRING unicode_string;
+    char ansi_text[] = "Xbox";
+
+    RtlInitAnsiString(&ansi_string, ansi_text);
+    RtlAnsiStringToUnicodeString(&unicode_string, &ansi_string, alloc_buffer);
+    RtlFreeUnicodeString(&unicode_string);
+    tests_passed &= assert_unicode_string(
+        &unicode_string,
+        0,
+        0,
+        NULL,
+        "Free unicode string"
+    );
+
+    print_test_footer(func_num, func_name, tests_passed);
 }
 
 void test_RtlGetCallersAddress(){
@@ -254,7 +412,34 @@ void test_RtlInitAnsiString(){
 }
 
 void test_RtlInitUnicodeString(){
-    /* FIXME: This is a stub! implement this function! */
+    const char* func_num = "0x0122";
+    const char* func_name = "RtlInitUnicodeString";
+    BOOL tests_passed = 1;
+    UNICODE_STRING unicode_string;
+    WCHAR string[] = L"Xbox";
+    print_test_header(func_num, func_name);
+
+    unicode_string.Length = 100;
+    unicode_string.MaximumLength = 200;
+    RtlInitUnicodeString(&unicode_string, NULL);
+    tests_passed &= assert_unicode_string(
+        &unicode_string,
+        0,
+        0,
+        NULL,
+        "Src str = NULL, Length = 0"
+    );
+
+    RtlInitUnicodeString(&unicode_string, string);
+    tests_passed &= assert_unicode_string(
+        &unicode_string,
+        4*2,
+        (4+1)*2,
+        string,
+        "Use char array to create unicode string"
+    );
+
+    print_test_footer(func_num, func_name, tests_passed);
 }
 
 void test_RtlInitializeCriticalSection(){


### PR DESCRIPTION
Sorry for the delay. So:

 Currently, all AV Tests are disabled due to a mistake that cause cxbx to crash. I'll try to fix the address soon.

Added these Rtl Tests:
* RtlCharToInteger
* RtlCopyString
* RtlEqualString (currently disabled because not working on my real xbox)
* RtlEqualUnicodeString
* RtlFreeUnicodeString
* RtlInitUnicodeString

My next step is to fix the AV tests, the RtlEqualString and then continue with Rtl tests implementation.


PS: Just for reference, Cxbx currently fails on RtlCompareMemoryUlong and RtlEqualUnicodeString