### PR TITLE
Add test for RtlCompareMemory

### DIFF
--- a/av_tests.c
+++ b/av_tests.c
@@ -4,20 +4,19 @@
 
 
 void test_AvGetSavedDataAddress(){
-/*    if(!is_emu){
+    if(!is_emu){
          print("0x0001 - AvGetSavedDataAddress: Skipped (due to real hadrware) / value: %x",AvGetSavedDataAddress());
          return;
     }
     AvSetSavedDataAddress((void*) 0x12345678);
     AvGetSavedDataAddress()==(void*)0x12345678 ? print("0x0001 - AvGetSavedDataAddress: Good") : print("0x0001 - AvGetSavedDataAddress: Faulty");
-    */
 }
 
 void test_AvSendTVEncoderOption(){
     /* FIXME: there are other functions such as AV_OPTION_QUERY_MODE, AV_QUERY_ENCODER_TYPE, AV_OPTION_WIDESCREEN etc*/
-    /*unsigned long res = 0;
+    unsigned long res = 0;
     AvSendTVEncoderOption(NULL, 6, 0, &res);
-    print("0x0002 - AvSendTVEncoderOption: %d (0=AV_PACK_NONE 1=AV_PACK_STANDARD 2=AV_PACK_RFU 3=AV_PACK_SCART 4=AV_PACK_HDTV 5=AV_PACK_VGA 6=AV_PACK_SVIDEO)", res);*/
+    print("0x0002 - AvSendTVEncoderOption: %d (0=AV_PACK_NONE 1=AV_PACK_STANDARD 2=AV_PACK_RFU 3=AV_PACK_SCART 4=AV_PACK_HDTV 5=AV_PACK_VGA 6=AV_PACK_SVIDEO)", res);
 }
 
 void test_AvSetDisplayMode(){
@@ -25,9 +24,6 @@ void test_AvSetDisplayMode(){
          print("0x0003 - AvSetDisplayMode: Skipped (due to real hadrware)");
          return;
     }
-
-
-
     // FATAL - Fails on emulator as of april 6th, 2018
     return;
     AvSetDisplayMode(NULL, 0, 0, 0, 0, 0) == 0L ? print("0x0003 - AvSetDisplayMode: 0 (Good)") : print("0x0003 - AvSetDisplayMode: !=0 (Faulty)");
@@ -35,10 +31,10 @@ void test_AvSetDisplayMode(){
 }
 
 void test_AvSetSavedDataAddress(){
-/*    if(!is_emu){
+    if(!is_emu){
          print("0x0004 - AvSetSavedDataAddress: Skipped (due to real hadrware)");
          return;
     }
     AvSetSavedDataAddress((void*) 0x12345678);
-    AvGetSavedDataAddress()==(void*)0x12345678 ? print("0x0004 - AvSetSavedDataAddress: Good") : print("0x0004 - AvSetSavedDataAddress: Faulty");*/
+    AvGetSavedDataAddress()==(void*)0x12345678 ? print("0x0004 - AvSetSavedDataAddress: Good") : print("0x0004 - AvSetSavedDataAddress: Faulty");
 }

--- a/rtl_assertions.c
+++ b/rtl_assertions.c
@@ -48,3 +48,15 @@ static BOOL assert_unicode_string(
 
     ASSERT_FOOTER(test_name)
 }
+
+BOOL assert_rtl_compared_bytes(
+    SIZE_T num_matching_bytes,
+    SIZE_T expected_matching_bytes,
+    const char* test_name
+) {
+    ASSERT_HEADER
+
+    GEN_CHECK(num_matching_bytes, expected_matching_bytes, "num_matching_bytes");
+
+    ASSERT_FOOTER(test_name)
+}

--- a/rtl_assertions.h
+++ b/rtl_assertions.h
@@ -27,4 +27,6 @@ BOOL assert_unicode_string(
     const char*
 );
 
+BOOL assert_rtl_compared_bytes(SIZE_T, SIZE_T, const char*);
+
 #endif // RTL_ASSERTIONS_H

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -156,7 +156,36 @@ void test_RtlCharToInteger(){
 }
 
 void test_RtlCompareMemory(){
-    /* FIXME: This is a stub! implement this function! */
+    const char* func_num = "0x010C";
+    const char* func_name = "RtlCompareMemory";
+    BOOL tests_passed = 1;
+    print_test_header(func_num, func_name);
+
+    uint32_t num1 = 0;
+    uint32_t num2 = 0;
+    VOID* num1_ptr = (VOID*)&num1;
+    VOID* num2_ptr = (VOID*)&num2;
+
+    SIZE_T bytes_matching = RtlCompareMemory(num1_ptr, num2_ptr, 0);
+    assert_rtl_compared_bytes(bytes_matching, 0, "Check 0 bytes of memory");
+
+    bytes_matching = RtlCompareMemory(num1_ptr, num2_ptr, sizeof(num1));
+    assert_rtl_compared_bytes(bytes_matching, sizeof(num1), "Both nums 0, should match");
+
+    num1 |= 0x80000000;
+    bytes_matching = RtlCompareMemory(num1_ptr, num2_ptr, sizeof(num1));
+    assert_rtl_compared_bytes(bytes_matching, sizeof(num1) - 1, "Only 3 bytes should match");
+
+    num2 |= 0x4000;
+    bytes_matching = RtlCompareMemory(num1_ptr, num2_ptr, sizeof(num1));
+    assert_rtl_compared_bytes(bytes_matching, sizeof(num1) - 3, "Only 1 byte should match");
+
+    num2 |= 0x80000000;
+    num1 |= 0x4000;
+    bytes_matching = RtlCompareMemory(num1_ptr, num2_ptr, sizeof(num1));
+    assert_rtl_compared_bytes(bytes_matching, sizeof(num1), "All bytes should match again");
+
+    print_test_footer(func_num, func_name, tests_passed);
 }
 
 void test_RtlCompareMemoryUlong(){


### PR DESCRIPTION
Added a simple test for RtlCompareMemory. Also added back in the Av tests that are not causing the crash on Cxbx.