### PR TITLE
Add two tests, comment out RtlUpperString, and refactor RtlUpperChar

### DIFF
--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -623,7 +623,38 @@ void test_RtlFillMemory(){
 }
 
 void test_RtlFillMemoryUlong(){
-    /* FIXME: This is a stub! implement this function! */
+    const char* func_num = "0x011D";
+    const char* func_name = "RtlFillMemoryUlong";
+    BOOL tests_passed = 1;
+    print_test_header(func_num, func_name);
+
+    const BYTE buf_len = 20;
+    ULONG buffer[buf_len];
+    SIZE_T lengths[] = {1, 10, buf_len};
+    ULONG patterns[] = {0x1, 0x2FFF, 0xFFFFFFFF};
+    BOOL individual_test_passes = 1;
+
+    RtlZeroMemory(buffer, buf_len * sizeof(ULONG));
+    for(uint8_t i = 0; i < sizeof(lengths) / sizeof(SIZE_T); i++) {
+        RtlFillMemoryUlong(buffer, lengths[i] * sizeof(ULONG), patterns[i]);
+        for(uint8_t y = 0; y < buf_len; y++) {
+            ULONG expected_pattern = (y < lengths[i]) ? patterns[i] : 0x0;
+            if(buffer[y] != expected_pattern) {
+                print("  ERROR: For index = %u, got = 0x%x, expected = 0x%x", y, buffer[y], expected_pattern);
+                individual_test_passes = 0;
+            }
+        }
+        if(individual_test_passes) {
+            print("  Test PASSED for length = %u, pattern = 0x%x", lengths[i], patterns[i]);
+        }
+        else {
+            print("  Test FAILED for length = %u, pattern = 0x%x", lengths[i], patterns[i]);
+            tests_passed = 0;
+        }
+        individual_test_passes = 1;
+    }
+
+    print_test_footer(func_num, func_name, tests_passed);
 }
 
 void test_RtlFreeAnsiString(){

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -974,76 +974,77 @@ void test_RtlUpperChar(){
     print_test_footer(func_num, func_name, tests_passed);
 }
 
+// FIXME - This test hangs on real hardware but passes on Cxbx-R
 void test_RtlUpperString(){
-    const char* func_num = "0x013D";
-    const char* func_name = "RtlUpperString";
-    BOOL tests_passed = 1;
-    print_test_header(func_num, func_name);
-
-    char rnd_letter;
-    char rnd_letters[101];
-
-    for(int k=0; k<100; k++){ // we use XGetTickCount as a rand() replacement
-        rnd_letter = "abcdefghijklmnopqrstuvwxyz"[(int)XGetTickCount() % 26];
-        rnd_letters[k] = rnd_letter;
-    }
-    rnd_letters[100] = '\0';
-
-    ANSI_STRING src_str;
-    ANSI_STRING res_str;
-
-    /* Empty String Test */
-    RtlInitAnsiString(&src_str, "");
-    RtlInitAnsiString(&res_str, "");
-    RtlUpperString(&res_str, &src_str);
-    tests_passed &= strcmp(res_str.Buffer, "") == 0 ? 1 : 0;
-    if(!tests_passed)
-        print("RtlUpperString Lowercase String Test Failed");
-
-    /* Lowercase String Test */
-    RtlInitAnsiString(&src_str, "xbox");
-    RtlInitAnsiString(&res_str, "xbox");
-    RtlUpperString(&res_str, &src_str);
-    tests_passed &= strcmp(res_str.Buffer, "XBOX") == 0 ? 1 : 0;
-    if(!tests_passed)
-        print("RtlUpperString Lowercase String Test Failed");
-
-    /* Lowercase Single Character Test */
-    RtlInitAnsiString(&src_str, "x");
-    RtlInitAnsiString(&res_str, "x");
-    RtlUpperString(&res_str, &src_str);
-    tests_passed &= strcmp(res_str.Buffer, "X") == 0 ? 1 : 0;
-    if(!tests_passed)
-        print("RtlUpperString Lowercase Single Character Test Failed");
-
-    /* Uppercase Single Character Test */
-    RtlInitAnsiString(&src_str, "X");
-    RtlInitAnsiString(&res_str, "X");
-    RtlUpperString(&res_str, &src_str);
-    tests_passed &= strcmp(res_str.Buffer, "X") == 0 ? 1 : 0;
-    if(!tests_passed)
-        print("RtlUpperString Uppercase Single Character Test Failed"); 
-
-    /* 100 Lowercase Characters Test */
-    RtlInitAnsiString(&src_str, rnd_letters);
-    RtlInitAnsiString(&res_str, rnd_letters);
-    RtlUpperString(&res_str, &src_str);
-    for(int k=0; k<100; k++){
-        if(res_str.Buffer[k] != toupper(rnd_letters[k]))
-            tests_passed = 0;
-    }
-    if(!tests_passed)
-        print("RtlUpperString 100 Lowercase Characters Test Failed");
-
-    /* Uppercase String Test */
-    RtlInitAnsiString(&src_str, "XBOX");
-    RtlInitAnsiString(&res_str, "XBOX");
-    RtlUpperString(&res_str, &src_str);
-    tests_passed &= strcmp(res_str.Buffer, "XBOX") == 0 ? 1 : 0;
-    if(!tests_passed)
-        print("RtlUpperString Uppercase String Test Failed");
-
-    print_test_footer(func_num, func_name, tests_passed);
+//    const char* func_num = "0x013D";
+//    const char* func_name = "RtlUpperString";
+//    BOOL tests_passed = 1;
+//    print_test_header(func_num, func_name);
+//
+//    char rnd_letter;
+//    char rnd_letters[101];
+//
+//    for(int k=0; k<100; k++){ // we use XGetTickCount as a rand() replacement
+//        rnd_letter = "abcdefghijklmnopqrstuvwxyz"[(int)XGetTickCount() % 26];
+//        rnd_letters[k] = rnd_letter;
+//    }
+//    rnd_letters[100] = '\0';
+//
+//    ANSI_STRING src_str;
+//    ANSI_STRING res_str;
+//
+//    /* Empty String Test */
+//    RtlInitAnsiString(&src_str, "");
+//    RtlInitAnsiString(&res_str, "");
+//    RtlUpperString(&res_str, &src_str);
+//    tests_passed &= strcmp(res_str.Buffer, "") == 0 ? 1 : 0;
+//    if(!tests_passed)
+//        print("RtlUpperString Lowercase String Test Failed");
+//
+//    /* Lowercase String Test */
+//    RtlInitAnsiString(&src_str, "xbox");
+//    RtlInitAnsiString(&res_str, "xbox");
+//    RtlUpperString(&res_str, &src_str);
+//    tests_passed &= strcmp(res_str.Buffer, "XBOX") == 0 ? 1 : 0;
+//    if(!tests_passed)
+//        print("RtlUpperString Lowercase String Test Failed");
+//
+//    /* Lowercase Single Character Test */
+//    RtlInitAnsiString(&src_str, "x");
+//    RtlInitAnsiString(&res_str, "x");
+//    RtlUpperString(&res_str, &src_str);
+//    tests_passed &= strcmp(res_str.Buffer, "X") == 0 ? 1 : 0;
+//    if(!tests_passed)
+//        print("RtlUpperString Lowercase Single Character Test Failed");
+//
+//    /* Uppercase Single Character Test */
+//    RtlInitAnsiString(&src_str, "X");
+//    RtlInitAnsiString(&res_str, "X");
+//    RtlUpperString(&res_str, &src_str);
+//    tests_passed &= strcmp(res_str.Buffer, "X") == 0 ? 1 : 0;
+//    if(!tests_passed)
+//        print("RtlUpperString Uppercase Single Character Test Failed"); 
+//
+//    /* 100 Lowercase Characters Test */
+//    RtlInitAnsiString(&src_str, rnd_letters);
+//    RtlInitAnsiString(&res_str, rnd_letters);
+//    RtlUpperString(&res_str, &src_str);
+//    for(int k=0; k<100; k++){
+//        if(res_str.Buffer[k] != toupper(rnd_letters[k]))
+//            tests_passed = 0;
+//    }
+//    if(!tests_passed)
+//        print("RtlUpperString 100 Lowercase Characters Test Failed");
+//
+//    /* Uppercase String Test */
+//    RtlInitAnsiString(&src_str, "XBOX");
+//    RtlInitAnsiString(&res_str, "XBOX");
+//    RtlUpperString(&res_str, &src_str);
+//    tests_passed &= strcmp(res_str.Buffer, "XBOX") == 0 ? 1 : 0;
+//    if(!tests_passed)
+//        print("RtlUpperString Uppercase String Test Failed");
+//
+//    print_test_footer(func_num, func_name, tests_passed);
 }
 
 void test_RtlUshortByteSwap(){

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -955,13 +955,21 @@ void test_RtlUpperChar(){
     BOOL tests_passed = 1;
     print_test_header(func_num, func_name);
 
-    tests_passed &= (RtlUpperChar('a') == 'A' ? 1 : 0);
-    tests_passed &= (RtlUpperChar('A') == 'A' ? 1 : 0);
-    tests_passed &= (RtlUpperChar('1') == '1' ? 1 : 0);
-    tests_passed &= (RtlUpperChar('!') == '!' ? 1 : 0);
-    tests_passed &= (RtlUpperChar(' ') == ' ' ? 1 : 0);
-    tests_passed &= (RtlUpperChar((char)127) == (char)127 ? 1 : 0); // This is DEL
-    tests_passed &= (RtlUpperChar((char)-1) == '?' ? 1 : 0);
+    // -1 = ?, 127 = DEL
+    CHAR inputs[] =             {'a', 'A', '1', '!', ' ', (CHAR)127, (CHAR)-1};
+    CHAR expected_outputs[] =   {'A', 'A', '1', '!', ' ', (CHAR)127, '?'};
+    CHAR result;
+
+    for(uint8_t i = 0; i < sizeof(inputs) / sizeof(CHAR); i++) {
+        result = RtlUpperChar(inputs[i]);
+        if(result == expected_outputs[i]) {
+            print("  Test PASSED for input '%c'", inputs[i]);
+        }
+        else {
+            tests_passed = 0;
+            print("  Test FAILED for input = '%c', got = '%c', expected = '%c'", inputs[i], result, expected_outputs[i]);
+        }
+    }
 
     print_test_footer(func_num, func_name, tests_passed);
 }

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -619,7 +619,38 @@ void test_RtlExtendedMagicDivide(){
 }
 
 void test_RtlFillMemory(){
-    /* FIXME: This is a stub! implement this function! */
+    const char* func_num = "0x011C";
+    const char* func_name = "RtlFillMemory";
+    BOOL tests_passed = 1;
+    print_test_header(func_num, func_name);
+
+    const BYTE buf_len = 20;
+    BYTE buffer[buf_len];
+    DWORD lengths[] = {1, 10, buf_len};
+    BYTE fills[] = {0x1, 0x2A, 0xFF};
+    BOOL individual_test_passes = 1;
+
+    RtlZeroMemory(buffer, buf_len);
+    for(uint8_t i = 0; i < sizeof(lengths) / sizeof(DWORD); i++) {
+        RtlFillMemory(buffer, lengths[i], fills[i]);
+        for(uint8_t y = 0; y < buf_len; y++) {
+            BYTE expected_fill = (y < lengths[i]) ? fills[i] : 0x00;
+            if(buffer[y] != expected_fill) {
+                print("  ERROR: For index = %u, got = 0x%x, expected = 0x%x", y, buffer[y], expected_fill);
+                individual_test_passes = 0;
+            }
+        }
+        if(individual_test_passes) {
+            print("  Test PASSED for length = %u, fill = 0x%x", lengths[i], fills[i]);
+        }
+        else {
+            print("  Test FAILED for length = %u, fill = 0x%x", lengths[i], fills[i]);
+            tests_passed = 0;
+        }
+        individual_test_passes = 1;
+    }
+
+    print_test_footer(func_num, func_name, tests_passed);
 }
 
 void test_RtlFillMemoryUlong(){


### PR DESCRIPTION
New tests added for RtlFillMemory and RtlFillMemoryUlong. Both are verified as passing on Cxbx-R and real hardware.

RtlUpperString is passing on Cxbx-R but is hanging on real hardware. I opened issue #36 to track the issue and commented out the test in the meantime.

RtlUpperChar has one test failure on Cxbx-R but passes on real hardware. Issue #38 created to track the failure. To figure out which input was failing I refactored the test as it originally only printed whether the entire test passed/failed.