### PR TITLE
Fix for RtlUpperString tests

### DIFF
--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -1158,77 +1158,76 @@ void test_RtlUpperChar(){
     print_test_footer(func_num, func_name, tests_passed);
 }
 
-// FIXME - This test hangs on real hardware but passes on Cxbx-R
 void test_RtlUpperString(){
-//    const char* func_num = "0x013D";
-//    const char* func_name = "RtlUpperString";
-//    BOOL tests_passed = 1;
-//    print_test_header(func_num, func_name);
-//
-//    char rnd_letter;
-//    char rnd_letters[101];
-//
-//    for(int k=0; k<100; k++){ // we use XGetTickCount as a rand() replacement
-//        rnd_letter = "abcdefghijklmnopqrstuvwxyz"[(int)XGetTickCount() % 26];
-//        rnd_letters[k] = rnd_letter;
-//    }
-//    rnd_letters[100] = '\0';
-//
-//    ANSI_STRING src_str;
-//    ANSI_STRING res_str;
-//
-//    /* Empty String Test */
-//    RtlInitAnsiString(&src_str, "");
-//    RtlInitAnsiString(&res_str, "");
-//    RtlUpperString(&res_str, &src_str);
-//    tests_passed &= strcmp(res_str.Buffer, "") == 0 ? 1 : 0;
-//    if(!tests_passed)
-//        print("RtlUpperString Lowercase String Test Failed");
-//
-//    /* Lowercase String Test */
-//    RtlInitAnsiString(&src_str, "xbox");
-//    RtlInitAnsiString(&res_str, "xbox");
-//    RtlUpperString(&res_str, &src_str);
-//    tests_passed &= strcmp(res_str.Buffer, "XBOX") == 0 ? 1 : 0;
-//    if(!tests_passed)
-//        print("RtlUpperString Lowercase String Test Failed");
-//
-//    /* Lowercase Single Character Test */
-//    RtlInitAnsiString(&src_str, "x");
-//    RtlInitAnsiString(&res_str, "x");
-//    RtlUpperString(&res_str, &src_str);
-//    tests_passed &= strcmp(res_str.Buffer, "X") == 0 ? 1 : 0;
-//    if(!tests_passed)
-//        print("RtlUpperString Lowercase Single Character Test Failed");
-//
-//    /* Uppercase Single Character Test */
-//    RtlInitAnsiString(&src_str, "X");
-//    RtlInitAnsiString(&res_str, "X");
-//    RtlUpperString(&res_str, &src_str);
-//    tests_passed &= strcmp(res_str.Buffer, "X") == 0 ? 1 : 0;
-//    if(!tests_passed)
-//        print("RtlUpperString Uppercase Single Character Test Failed"); 
-//
-//    /* 100 Lowercase Characters Test */
-//    RtlInitAnsiString(&src_str, rnd_letters);
-//    RtlInitAnsiString(&res_str, rnd_letters);
-//    RtlUpperString(&res_str, &src_str);
-//    for(int k=0; k<100; k++){
-//        if(res_str.Buffer[k] != toupper(rnd_letters[k]))
-//            tests_passed = 0;
-//    }
-//    if(!tests_passed)
-//        print("RtlUpperString 100 Lowercase Characters Test Failed");
-//
-//    /* Uppercase String Test */
-//    RtlInitAnsiString(&src_str, "XBOX");
-//    RtlInitAnsiString(&res_str, "XBOX");
-//    RtlUpperString(&res_str, &src_str);
-//    tests_passed &= strcmp(res_str.Buffer, "XBOX") == 0 ? 1 : 0;
-//    if(!tests_passed)
-//        print("RtlUpperString Uppercase String Test Failed");
-//
-//    print_test_footer(func_num, func_name, tests_passed);
+    const char* func_num = "0x013D";
+    const char* func_name = "RtlUpperString";
+    BOOL tests_passed = 1;
+    print_test_header(func_num, func_name);
+
+    char rnd_letter;
+    char rnd_letters[101];
+
+    for(int k=0; k<100; k++){ // we use XGetTickCount as a rand() replacement
+        rnd_letter = "abcdefghijklmnopqrstuvwxyz"[(int)XGetTickCount() % 26];
+        rnd_letters[k] = rnd_letter;
+    }
+    rnd_letters[100] = '\0';
+
+    ANSI_STRING src_str;
+    ANSI_STRING res_str;
+
+    /* Empty String Test */
+    RtlInitAnsiString(&src_str, "");
+    RtlInitAnsiString(&res_str, "");
+    RtlUpperString(&res_str, &src_str);
+    tests_passed &= strcmp(res_str.Buffer, "") == 0 ? 1 : 0;
+    if(!tests_passed)
+        print("RtlUpperString Lowercase String Test Failed");
+
+    /* Lowercase String Test */
+    RtlInitAnsiString(&src_str, "xbox");
+    RtlInitAnsiString(&res_str, "xbox");
+    RtlUpperString(&res_str, &src_str);
+    tests_passed &= strcmp(res_str.Buffer, "XBOX") == 0 ? 1 : 0;
+    if(!tests_passed)
+        print("RtlUpperString Lowercase String Test Failed");
+
+    /* Lowercase Single Character Test */
+    RtlInitAnsiString(&src_str, "x");
+    RtlInitAnsiString(&res_str, "x");
+    RtlUpperString(&res_str, &src_str);
+    tests_passed &= strcmp(res_str.Buffer, "X") == 0 ? 1 : 0;
+    if(!tests_passed)
+        print("RtlUpperString Lowercase Single Character Test Failed");
+
+    /* Uppercase Single Character Test */
+    RtlInitAnsiString(&src_str, "X");
+    RtlInitAnsiString(&res_str, "X");
+    RtlUpperString(&res_str, &src_str);
+    tests_passed &= strcmp(res_str.Buffer, "X") == 0 ? 1 : 0;
+    if(!tests_passed)
+        print("RtlUpperString Uppercase Single Character Test Failed"); 
+
+    /* 100 Lowercase Characters Test */
+    RtlInitAnsiString(&src_str, rnd_letters);
+    RtlInitAnsiString(&res_str, rnd_letters);
+    RtlUpperString(&res_str, &src_str);
+    for(int k=0; k<100; k++){
+        if(res_str.Buffer[k] != toupper(rnd_letters[k]))
+            tests_passed = 0;
+    }
+    if(!tests_passed)
+        print("RtlUpperString 100 Lowercase Characters Test Failed");
+
+    /* Uppercase String Test */
+    RtlInitAnsiString(&src_str, "XBOX");
+    RtlInitAnsiString(&res_str, "XBOX");
+    RtlUpperString(&res_str, &src_str);
+    tests_passed &= strcmp(res_str.Buffer, "XBOX") == 0 ? 1 : 0;
+    if(!tests_passed)
+        print("RtlUpperString Uppercase String Test Failed");
+
+    print_test_footer(func_num, func_name, tests_passed);
 }
 
 void test_RtlUshortByteSwap(){

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -1175,42 +1175,45 @@ void test_RtlUpperString(){
 
     ANSI_STRING src_str;
     ANSI_STRING res_str;
+    char res_buf[256];
+
+    /* Initialize res_buf so RtlInitAnsiString works correctly */
+    for (int i=0; i<255; i++)
+        res_buf[i] = '0';
+    res_buf[255] = 0;
+
+    RtlInitAnsiString(&res_str, res_buf);
 
     /* Empty String Test */
     RtlInitAnsiString(&src_str, "");
-    RtlInitAnsiString(&res_str, "");
     RtlUpperString(&res_str, &src_str);
-    tests_passed &= strcmp(res_str.Buffer, "") == 0 ? 1 : 0;
+    tests_passed &= strncmp(res_str.Buffer, "", res_str.Length) == 0 ? 1 : 0;
     if(!tests_passed)
         print("RtlUpperString Lowercase String Test Failed");
 
     /* Lowercase String Test */
     RtlInitAnsiString(&src_str, "xbox");
-    RtlInitAnsiString(&res_str, "xbox");
     RtlUpperString(&res_str, &src_str);
-    tests_passed &= strcmp(res_str.Buffer, "XBOX") == 0 ? 1 : 0;
+    tests_passed &= strncmp(res_str.Buffer, "XBOX", res_str.Length) == 0 ? 1 : 0;
     if(!tests_passed)
         print("RtlUpperString Lowercase String Test Failed");
 
     /* Lowercase Single Character Test */
     RtlInitAnsiString(&src_str, "x");
-    RtlInitAnsiString(&res_str, "x");
     RtlUpperString(&res_str, &src_str);
-    tests_passed &= strcmp(res_str.Buffer, "X") == 0 ? 1 : 0;
+    tests_passed &= strncmp(res_str.Buffer, "X", res_str.Length) == 0 ? 1 : 0;
     if(!tests_passed)
         print("RtlUpperString Lowercase Single Character Test Failed");
 
     /* Uppercase Single Character Test */
     RtlInitAnsiString(&src_str, "X");
-    RtlInitAnsiString(&res_str, "X");
     RtlUpperString(&res_str, &src_str);
-    tests_passed &= strcmp(res_str.Buffer, "X") == 0 ? 1 : 0;
+    tests_passed &= strncmp(res_str.Buffer, "X", res_str.Length) == 0 ? 1 : 0;
     if(!tests_passed)
         print("RtlUpperString Uppercase Single Character Test Failed"); 
 
     /* 100 Lowercase Characters Test */
     RtlInitAnsiString(&src_str, rnd_letters);
-    RtlInitAnsiString(&res_str, rnd_letters);
     RtlUpperString(&res_str, &src_str);
     for(int k=0; k<100; k++){
         if(res_str.Buffer[k] != toupper(rnd_letters[k]))
@@ -1221,9 +1224,8 @@ void test_RtlUpperString(){
 
     /* Uppercase String Test */
     RtlInitAnsiString(&src_str, "XBOX");
-    RtlInitAnsiString(&res_str, "XBOX");
     RtlUpperString(&res_str, &src_str);
-    tests_passed &= strcmp(res_str.Buffer, "XBOX") == 0 ? 1 : 0;
+    tests_passed &= strncmp(res_str.Buffer, "XBOX", res_str.Length) == 0 ? 1 : 0;
     if(!tests_passed)
         print("RtlUpperString Uppercase String Test Failed");
 


### PR DESCRIPTION
This fixes the test cases for RtlUpperString. There were three problems with it:
1. res_str was initialized with a string literal, making res_str.Buffer point to a `const char *` which is not allowed for the result buffer.
2. res_str was initialized with the same string literal as src_str, making res_str.Buffer point to the same address as src_str.Buffer.
3. strcmp() was used for the comparison, which won't yield correct results due to RtlUpperString ignoring the null terminator.

I did not run the tests with CxBx-Reloaded, but they worked on real hardware.

Fixes #36.