### PR TITLE
Use new wchar xlibc function in nxdk for the RtlAppendUnicodeStringToString test

### DIFF
--- a/output.c
+++ b/output.c
@@ -23,7 +23,7 @@ void print(char* str, ...){
     /*******************************/
 
     /*** PRINT ON CONSOLE (CXBX) ***/
-    DbgPrint("%s\n", buffer);
+    DbgPrint("%s", buffer);
     /*******************************/
 
     // Write information to logfile

--- a/rtl_assertions.c
+++ b/rtl_assertions.c
@@ -1,5 +1,6 @@
 #include "rtl_assertions.h"
 #include "assertion_defines.h"
+#include <wchar.h>
 
 BOOL assert_critical_section_equals(
     PRTL_CRITICAL_SECTION crit_section,
@@ -44,7 +45,14 @@ static BOOL assert_unicode_string(
 
     GEN_CHECK(string->Length, expected_Length, "Length");
     GEN_CHECK(string->MaximumLength, expected_MaximumLength, "MaximumLength");
-    GEN_CHECK(string->Buffer, expected_Buffer, "Buffer");
+
+    if(expected_Buffer == NULL) {
+        GEN_CHECK(string->Buffer, NULL, "Buffer is null");
+    }
+    else {
+        int result = wcscmp(string->Buffer, expected_Buffer);
+        GEN_CHECK(result, 0, "wcscmp result of Buffer");
+    }
 
     ASSERT_FOOTER(test_name)
 }

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <wchar.h>
 
 #include "output.h"
 #include "common_assertions.h"
@@ -98,35 +99,36 @@ void test_RtlAppendUnicodeStringToString(){
     BOOL tests_passed = 1;
     print_test_header(func_num, func_name);
 
-    // wcslen does not work because nxdk fails to find wchar.h
-    const WCHAR src_text[] = L"Xbox";
-    const uint8_t num_chars_in_src = 4;
-    WCHAR buffer[num_chars_in_src * 2];
-    const uint8_t num_buf_bytes = sizeof(buffer);
     UNICODE_STRING src_str, dest_str;
+    RtlInitUnicodeString(&src_str, L"Xbox");
+    const size_t num_chars_in_src = wcslen(src_str.Buffer);
+    WCHAR buffer[(num_chars_in_src + 1) * 2]; // Add 1 to hold the \0 end character
+    WCHAR expected_result[(num_chars_in_src + 1) * 2];
+    const size_t num_buf_bytes = sizeof(buffer);
 
-    RtlInitUnicodeString(&src_str, src_text);
     dest_str.Length = 0;
     dest_str.MaximumLength = num_buf_bytes;
     dest_str.Buffer = buffer;
+    wcscpy(expected_result, src_str.Buffer);
 
     NTSTATUS ret = RtlAppendUnicodeStringToString(&dest_str, &src_str);
     tests_passed &= assert_NTSTATUS(ret, STATUS_SUCCESS, func_name);
     tests_passed &= assert_unicode_string(
         &dest_str,
-        num_chars_in_src * sizeof(WCHAR),
+        wcslen(expected_result) * sizeof(WCHAR),
         num_buf_bytes,
-        buffer,
+        expected_result,
         "Append src str to empty dest str"
     );
 
+    wcscat(expected_result, src_str.Buffer);
     ret = RtlAppendUnicodeStringToString(&dest_str, &src_str);
     tests_passed &= assert_NTSTATUS(ret, STATUS_SUCCESS, func_name);
     tests_passed &= assert_unicode_string(
         &dest_str,
-        num_chars_in_src * 2 * sizeof(WCHAR),
+        wcslen(expected_result) * sizeof(WCHAR),
         num_buf_bytes,
-        buffer,
+        expected_result,
         "Append src str to dest str again"
     );
 

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -109,7 +109,7 @@ void test_RtlAppendUnicodeStringToString(){
     dest_str.Length = 0;
     dest_str.MaximumLength = num_buf_bytes;
     dest_str.Buffer = buffer;
-    wcscpy(expected_result, src_str.Buffer);
+    wcsncpy(expected_result, src_str.Buffer, num_chars_in_src + 1);
 
     NTSTATUS ret = RtlAppendUnicodeStringToString(&dest_str, &src_str);
     tests_passed &= assert_NTSTATUS(ret, STATUS_SUCCESS, func_name);


### PR DESCRIPTION
After this pull request to nxdk is merged, this pull request can be merged: https://github.com/XboxDev/nxdk/pull/79 

I updated the first unicode string test function to 1. Use the new wchar xlibc functions in nxdk to cleanup p the code and 2. Actually compare the result buffer to an expected unicode string. **This greatly improves testing ability** as before I was just checking if the pointer of the buffer matched itself.
