### PR TITLE
Add RtlExtendedLargeIntegerDivide test

### DIFF
--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -502,15 +502,14 @@ void test_RtlDowncaseUnicodeChar(){
     WCHAR expected_output[] = {L' ', L'w', L'w', L'x', L']', L'$'};
 
     for(uint8_t i = 0; i < sizeof(input) / sizeof(WCHAR); i++) {
+        const char* result_text = passed_text;
         result = RtlDowncaseUnicodeChar(input[i]);
-        if(result == expected_output[i]) {
-            // For some reason print does not work with %S to display input chars
-            print("  Test PASSED for input #%u", i);
-        }
-        else {
+        if(result != expected_output[i]) {
             tests_passed = 0;
-            print("  Test FAILED for input #%u", i);
+            result_text = failed_text;
         }
+        // Change %u to %S when printf supports %S in nxdk
+        print("  Test %s for input #%u", result_text, i);
     }
 
     print_test_footer(func_num, func_name, tests_passed);
@@ -609,17 +608,15 @@ void test_RtlEqualString(){
 
     BOOLEAN result;
     for(uint8_t i = 0; i < sizeof(str1_inputs) / sizeof(ANSI_STRING*); i++) {
+        const char* result_text = passed_text;
         result = RtlEqualString(str1_inputs[i], str2_inputs[i], case_insensitive[i]);
-        if(result == expected_result[i]) {
-            print("  Test PASSED for str1 = %s, str2 = %s, case insensitive = %x.",
-                  str1_inputs[i]->Buffer, str2_inputs[i]->Buffer, case_insensitive[i]);
-        }
-        else {
+        if(result != expected_result[i]) {
             tests_passed = 0;
-            print("  Test FAILED for str1 = %s, str2 = %s, case insensitive = %x. Expected = %x, got = %x",
-                  str1_inputs[i]->Buffer, str2_inputs[i]->Buffer, case_insensitive[i], expected_result[i],
-                  result);
+            result_text = failed_text;
         }
+        print("  Test %s for str1 = %s, str2 = %s, case insensitive = %x. Expected = %x, got = %x",
+              result_text, str1_inputs[i]->Buffer, str2_inputs[i]->Buffer, case_insensitive[i], expected_result[i],
+              result);
     }
 
     print_test_footer(func_num, func_name, tests_passed);
@@ -694,6 +691,7 @@ void test_RtlFillMemory(){
 
     RtlZeroMemory(buffer, buf_len);
     for(uint8_t i = 0; i < sizeof(lengths) / sizeof(DWORD); i++) {
+        const char* result_text = passed_text;
         RtlFillMemory(buffer, lengths[i], fills[i]);
         for(uint8_t y = 0; y < buf_len; y++) {
             BYTE expected_fill = (y < lengths[i]) ? fills[i] : 0x00;
@@ -702,13 +700,11 @@ void test_RtlFillMemory(){
                 individual_test_passes = 0;
             }
         }
-        if(individual_test_passes) {
-            print("  Test PASSED for length = %u, fill = 0x%x", lengths[i], fills[i]);
-        }
-        else {
-            print("  Test FAILED for length = %u, fill = 0x%x", lengths[i], fills[i]);
+        if(!individual_test_passes) {
             tests_passed = 0;
+            result_text = failed_text;
         }
+        print("  Test %s for length = %u, fill = 0x%x", result_text, lengths[i], fills[i]);
         individual_test_passes = 1;
     }
 
@@ -729,6 +725,7 @@ void test_RtlFillMemoryUlong(){
 
     RtlZeroMemory(buffer, buf_len * sizeof(ULONG));
     for(uint8_t i = 0; i < sizeof(lengths) / sizeof(SIZE_T); i++) {
+        const char* result_text = passed_text;
         RtlFillMemoryUlong(buffer, lengths[i] * sizeof(ULONG), patterns[i]);
         for(uint8_t y = 0; y < buf_len; y++) {
             ULONG expected_pattern = (y < lengths[i]) ? patterns[i] : 0x0;
@@ -737,13 +734,11 @@ void test_RtlFillMemoryUlong(){
                 individual_test_passes = 0;
             }
         }
-        if(individual_test_passes) {
-            print("  Test PASSED for length = %u, pattern = 0x%x", lengths[i], patterns[i]);
-        }
-        else {
-            print("  Test FAILED for length = %u, pattern = 0x%x", lengths[i], patterns[i]);
+        if(!individual_test_passes) {
             tests_passed = 0;
+            result_text = failed_text;
         }
+        print("  Test %s for length = %u, pattern = 0x%x", result_text, lengths[i], patterns[i]);
         individual_test_passes = 1;
     }
 
@@ -1106,16 +1101,14 @@ void test_RtlUlongByteSwap(){
     ULONG result;
 
     for(uint8_t i = 0; i < sizeof(inputs) / sizeof(ULONG); i++) {
+        const char* result_text = passed_text;
         result = RtlUlongByteSwap(inputs[i]);
-        if(result == expected_results[i]) {
-            print("  Test PASSED: Expected = 0x%x for Input = 0x%x, Result = 0x%x",
-                  expected_results[i], inputs[i], result);
-        }
-        else {
+        if(result != expected_results[i]) {
             tests_passed = 0;
-            print("  Test FAILED: Expected = 0x%x for Input = 0x%x, Result = 0x%x",
-                  expected_results[i], inputs[i], result);
+            result_text = failed_text;
         }
+        print("  Test %s: Expected = 0x%x for Input = 0x%x, Result = 0x%x",
+              result_text, expected_results[i], inputs[i], result);
     }
 
     print_test_footer(func_num, func_name, tests_passed);
@@ -1278,16 +1271,14 @@ void test_RtlUshortByteSwap(){
     USHORT result;
 
     for(uint8_t i = 0; i < num_tests; i++) {
+        const char* result_text = passed_text;
         result = RtlUshortByteSwap(inputs[i]);
-        if(result == expected_results[i]) {
-            print("  Test PASSED: Expected = 0x%x for Input = 0x%x, Result = 0x%x",
-                  expected_results[i], inputs[i], result);
-        }
-        else {
+        if(result != expected_results[i]) {
             tests_passed = 0;
-            print("  Test FAILED: Expected = 0x%x for Input = 0x%x, Result = 0x%x",
-                  expected_results[i], inputs[i], result);
+            result_text = failed_text;
         }
+        print("  Test %s: Expected = 0x%x for Input = 0x%x, Result = 0x%x",
+              result_text, expected_results[i], inputs[i], result);
     }
 
     print_test_footer(func_num, func_name, tests_passed);

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -669,8 +669,50 @@ void test_RtlExtendedIntegerMultiply(){
     print_test_footer(func_num, func_name, tests_passed);
 }
 
+// A few things to note about this function:
+// 1. Passing NULL into the remainder field is legal.
+// 2. If the divisor = 0, then a STATUS_INTEGER_DIVIDE_BY_ZERO exception will be raised. There is no good way
+//    to test this as it will cause real hardware to hang.
+// 3. Real hardware implements this as a binary divison algorithm that emits interesting results when negative
+//    inputs are provided. The expected_results below are taken from what real hardware produces as output.
 void test_RtlExtendedLargeIntegerDivide(){
-    /* FIXME: This is a stub! implement this function! */
+    const char* func_num = "0x011A";
+    const char* func_name = "RtlExtendedLargeIntegerDivide";
+    BOOL tests_passed = 1;
+    print_test_header(func_num, func_name);
+
+    const LONGLONG dividends[]        = {1, 5, 300,                -300, 300,        -300};
+    const ULONG divisors[]            = {1, 8,   8,                   8,  -8,          -8};
+    const ULONG expected_remainders[] = {0, 5,   4,                 0x4, 300,        -244};
+    const LONGLONG expected_results[] = {1, 0,  37,  0x1fffffffffffffda,   0, 0x100000007};
+    LARGE_INTEGER dividend, result, e_result;
+    ULONG remainder;
+
+    for(uint8_t i = 0; i < sizeof(expected_results) / sizeof(LONGLONG); i++) {
+        const char* result_text = passed_text;
+        dividend.QuadPart = dividends[i];
+        e_result.QuadPart = expected_results[i];
+        result = RtlExtendedLargeIntegerDivide(dividend, divisors[i], &remainder);
+        if((result.QuadPart != e_result.QuadPart) || (remainder != expected_remainders[i])) {
+            tests_passed = 0;
+            result_text = failed_text;
+        }
+        // Dec 19th, 2018 - nxdk's printf does not support any format that will print 64 bits.
+        // Split the print into the high dword and low dword until nxdk can print them combined.
+        print("  Test %s: Expected Result = 0x%x %x with remainder = 0x%x for dividend = 0x%x %x and divisor = 0x%x, result = 0x%x %x with remainder = 0x%x",
+              result_text, e_result.u.HighPart, e_result.u.LowPart, expected_remainders[i],
+              dividend.u.HighPart, dividend.u.LowPart, divisors[i], result.u.HighPart, result.u.LowPart, remainder);
+    }
+
+    // Test remainder = NULL
+    dividend.QuadPart = 5;
+    result = RtlExtendedLargeIntegerDivide(dividend, 2, NULL);
+    if(result.QuadPart != 2) {
+        tests_passed = 0;
+        print("  Test with NULL remainder FAILED. Expected result = 0x2, got = 0x%x %x",
+              result.u.HighPart, result.u.LowPart);
+    }
+    print_test_footer(func_num, func_name, tests_passed);
 }
 
 void test_RtlExtendedMagicDivide(){

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -14,6 +14,9 @@
 #define STATUS_BUFFER_OVERFLOW      0x80000005
 #define STATUS_BUFFER_TOO_SMALL     0xC0000023
 
+const char* failed_text = "FAILED";
+const char* passed_text = "PASSED";
+
 void test_RtlAnsiStringToUnicodeString(){
     const char* func_num = "0x0104";
     const char* func_name = "RtlAnsiStringToUnicodeString";
@@ -645,7 +648,28 @@ void test_RtlEqualUnicodeString(){
 }
 
 void test_RtlExtendedIntegerMultiply(){
-    /* FIXME: This is a stub! implement this function! */
+    const char* func_num = "0x0119";
+    const char* func_name = "RtlExtendedIntegerMultiply";
+    BOOL tests_passed = 1;
+    print_test_header(func_num, func_name);
+
+    const LONGLONG multiplicands[]    = {1,  0,  15,   15, -15};
+    const LONG multipliers[]          = {0, -1,  15,  -15, -15};
+    const LONGLONG expected_results[] = {0,  0, 225, -225, 225};
+    LARGE_INTEGER multiplicand, result;
+
+    for(uint8_t i = 0; i < sizeof(expected_results) / sizeof(LONGLONG); i++) {
+        const char* result_text = passed_text;
+        multiplicand.QuadPart = multiplicands[i];
+        result = RtlExtendedIntegerMultiply(multiplicand, multipliers[i]);
+        if(result.QuadPart != expected_results[i]) {
+            tests_passed = 0;
+            result_text = failed_text;
+        }
+        print("  Test %s: Expected = %d for multiplicand = %d and multipler = %d, result = %d",
+              result_text, (LONG)expected_results[i], (LONG)multiplicands[i], (LONG)multipliers[i], (LONG)result.QuadPart);
+    }
+    print_test_footer(func_num, func_name, tests_passed);
 }
 
 void test_RtlExtendedLargeIntegerDivide(){


### PR DESCRIPTION
Building off my previous branch with RtlExtendedIntegerMultiply tests added, I found some interesting bugs in Cxbx-R's current implementation of RtlExtendedLargeIntegerDivide. Negative inputs for the dividend return interesting values due to how the binary division algorithm is implemented for this function. Expected values/remainders for the test were taken from running the inputs on real hardware and using what was returned.

A pull request has been submitted to Cxbx-R to fix implementation bugs to match real hardware: https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/pull/1519