### PR TITLE
Fix issue #56 and #45 (TEST BEFORE MERGE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ tests=1,25,3,F
 # BINARIES:
 You can download pre-built bins from here: https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/releases
 
+# TRAVIS CI:
+Current build status can be seen here: https://travis-ci.org/Cxbx-Reloaded/xbox_kernel_test_suite
+
 # USEFUL LINKS:
 * https://github.com/wine-mirror/wine/tree/master/dlls/ntdll/tests
 * https://github.com/wine-mirror/wine/tree/master/dlls/kernel32/tests

--- a/main.c
+++ b/main.c
@@ -9,6 +9,7 @@
 #include "global.h"
 #include "func_table.h"
 #include "vector.h"
+#include "string_extra.h"
 
 int load_conf_file(char *config_file_path) {
     int handle;

--- a/output.c
+++ b/output.c
@@ -1,7 +1,7 @@
 #include <pbkit/pbkit.h>
 #include <xboxrt/debug.h>
 #include <hal/fileio.h>
-
+#include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>

--- a/string_extra.c
+++ b/string_extra.c
@@ -1,0 +1,33 @@
+#include <stdlib.h>
+#include <string.h>
+
+// Public domain strtok_r() by Charlie Gordon
+char* strtok_r(char *str, const char *delim, char **nextp)
+{
+    char *ret;
+
+     if (str == NULL)
+    {
+        str = *nextp;
+    }
+
+     str += strspn(str, delim);
+
+     if (*str == '\0')
+    {
+        return NULL;
+    }
+
+     ret = str;
+
+     str += strcspn(str, delim);
+
+     if (*str)
+    {
+        *str++ = '\0';
+    }
+
+     *nextp = str;
+
+     return ret;
+}

--- a/string_extra.h
+++ b/string_extra.h
@@ -1,0 +1,6 @@
+#ifndef STRING_EXTRA_H
+#define STRING_EXTRA_H
+
+char* strtok_r(char *str, const char *delim, char **nextp);
+
+#endif


### PR DESCRIPTION
Hi all,
due to the recent addition of PDClib in nxdk, we weren't able to build xkts due to a missing function. A public domain implementation of this missing function (strtok_r) is now part of xkts. This fix issue #56 . Minor: I also added the Travis CI link to the README, fixing issue #45 .

Now, read carefully:
1) I tested xkts on my real xbox (screenshot: https://i.postimg.cc/Y9HpcH9k/photo-2019-04-26-14-45-39.jpg) and it works, but I was not able to test it using CxBx-R (I can't remember how we used to get the output log...).
2) I found a regression in XCreateFile: it the file already exist, it will NOT overwrite it.


Thank you,
Luca
