### PR TITLE
Update depreciated nxdk functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,20 @@
 language: c
 compiler: gcc
-dist: trusty
+dist: bionic
 os: linux
 notifications:
     email: false
 
 before_install:
-    # add LLVM repository
-    - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-    - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main" | sudo tee -a /etc/apt/sources.list
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo apt-get update -qq
     
 install:
     # install required packages
-    - sudo apt-get install build-essential flex bison clang git clang-7 lldb-7 llvm-7 llvm-7-dev -y
+    - sudo apt-get install build-essential flex bison clang git clang-8 lldb-8 llvm-8 llvm-8-dev -y
     # create an alias for lld-link
-    - alias lld-link=lld-link-7.0
+    - alias lld-link=lld-link-8.0
+    - alias clang=clang-8
     
 before_script:
     # clone NXDK repository to /home/travis/build/Cxbx-Reloaded/

--- a/main.c
+++ b/main.c
@@ -2,8 +2,6 @@
 #include <pbkit/pbkit.h>
 #include <hal/video.h>
 #include <hal/xbox.h>
-#include <winapi/fileapi.h>
-#include <winapi/handleapi.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -33,6 +31,7 @@ int load_conf_file(char *config_file_path) {
     DWORD file_size = GetFileSize(handle, NULL);
     if(file_size == INVALID_FILE_SIZE) {
         print("ERROR: Could not get file size for %s", config_file_path);
+        return -1;
     }
 
     char* buffer = (char *)malloc(file_size);

--- a/main.c
+++ b/main.c
@@ -1,11 +1,13 @@
-#include <xboxrt/debug.h>
+#include <hal/debug.h>
 #include <pbkit/pbkit.h>
 #include <hal/video.h>
 #include <hal/xbox.h>
-#include <hal/fileio.h>
+#include <winapi/fileapi.h>
+#include <winapi/handleapi.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <windows.h>
 #include "output.h"
 #include "global.h"
 #include "func_table.h"
@@ -13,40 +15,40 @@
 #include "string_extra.h"
 
 int load_conf_file(char *config_file_path) {
-    int handle;
-    unsigned int file_size = 0;
-    char *buffer;
-    unsigned int read = 0;
-    int result;
-
     print("Trying to open config file: %s", config_file_path);
-
-    result = XCreateFile(&handle,
+    HANDLE handle = CreateFile(
         config_file_path,
         GENERIC_READ,
         FILE_SHARE_READ,
+        0,
         OPEN_EXISTING,
-        FILE_ATTRIBUTE_NORMAL);
-    if(result != 0) {
+        FILE_ATTRIBUTE_NORMAL,
+        NULL
+    );
+    if(handle == INVALID_HANDLE_VALUE) {
         print("Could not open config file '%s' for read", config_file_path);
         return -1;
     }
 
-    XGetFileSize(handle, &file_size);
+    DWORD file_size = GetFileSize(handle, NULL);
+    if(file_size == INVALID_FILE_SIZE) {
+        print("ERROR: Could not get file size for %s", config_file_path);
+    }
 
-    buffer = malloc(file_size);
+    char* buffer = (char *)malloc(file_size);
     if(buffer == NULL) {
         print("Malloc failed for file_size %u", file_size);
         return -1;
     }
 
-    result = XReadFile(handle, buffer, file_size, &read);
-    if(result == 0 || read != file_size) {
-        print("Read failed for config file. result = %d, read = %u", file_size, read);
+    DWORD bytes_read = 0;
+    BOOL result = ReadFile(handle, buffer, file_size, &bytes_read, NULL);
+    if(result == 0 || bytes_read != file_size) {
+        print("Read failed for config file. result = %d, read = %u", file_size, bytes_read);
         return -1;
     }
 
-    XCloseHandle(handle);
+    CloseHandle(handle);
 
     char *line;
     char *rest = buffer;
@@ -99,7 +101,7 @@ void main(void){
     switch(pb_init()){
         case 0: break;
         default:
-            XSleep(2000);
+            Sleep(2000);
             XReboot();
             return;
     }
@@ -117,6 +119,6 @@ void main(void){
     vector_free(&tests_to_run);
     close_output_file();
 
-    XSleep(10000);
+    Sleep(10000);
     pb_kill();
 }

--- a/output.c
+++ b/output.c
@@ -1,7 +1,6 @@
 #include <pbkit/pbkit.h>
 #include <hal/debug.h>
-#include <winapi/fileapi.h>
-#include <winapi/handleapi.h>
+#include <windows.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -10,7 +9,7 @@
 #include "global.h"
 #include "output.h"
 
-static HANDLE output_filehandle = NULL;
+static HANDLE output_filehandle = INVALID_HANDLE_VALUE;
 
 void print(char* str, ...){
     va_list args;
@@ -78,7 +77,7 @@ int write_to_output_file(void* data_to_print, DWORD num_bytes_to_print) {
     }
 
     DWORD bytes_written;
-    int ret = WriteFile(
+    BOOL ret = WriteFile(
         output_filehandle,
         data_to_print,
         num_bytes_to_print,

--- a/output.c
+++ b/output.c
@@ -1,6 +1,7 @@
 #include <pbkit/pbkit.h>
-#include <xboxrt/debug.h>
-#include <hal/fileio.h>
+#include <hal/debug.h>
+#include <winapi/fileapi.h>
+#include <winapi/handleapi.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -9,7 +10,7 @@
 #include "global.h"
 #include "output.h"
 
-static int output_filehandle = 0;
+static HANDLE output_filehandle = NULL;
 
 void print(char* str, ...){
     va_list args;
@@ -49,38 +50,40 @@ void print_test_footer(
     }
 }
 
-int open_output_file(char* file_name) {
+void open_output_file(char* file_name) {
     if(is_emu) {
         print("Kernel Test Suite: Skipping creating %s because on emulator", file_name);
-        return 0;
+        return;
     }
 
     debugPrint("Creating file %s", file_name);
-    int ret = XCreateFile(
-        &output_filehandle,
+    output_filehandle = CreateFile(
         file_name,
         GENERIC_WRITE,
         FILE_SHARE_WRITE,
+        0,
         CREATE_ALWAYS,
-        FILE_ATTRIBUTE_NORMAL
+        FILE_ATTRIBUTE_NORMAL,
+        NULL
     );
-    if(ret != 0) {
+
+    if(output_filehandle == INVALID_HANDLE_VALUE) {
         debugPrint("ERROR: Could not create file %s", file_name);
     }
-    return ret;
 }
 
-int write_to_output_file(void* data_to_print, unsigned int num_bytes_to_print) {
+int write_to_output_file(void* data_to_print, DWORD num_bytes_to_print) {
     if(is_emu) {
         return 0;
     }
 
-    unsigned int bytes_written;
-    int ret = XWriteFile(
+    DWORD bytes_written;
+    int ret = WriteFile(
         output_filehandle,
         data_to_print,
         num_bytes_to_print,
-        &bytes_written
+        &bytes_written,
+        NULL
     );
     if(!ret) {
         debugPrint("ERROR: Could not write to output file");
@@ -93,11 +96,11 @@ int write_to_output_file(void* data_to_print, unsigned int num_bytes_to_print) {
     return ret;
 }
 
-int close_output_file() {
+BOOL close_output_file() {
     if(is_emu) {
         return 0;
     }
-    int ret = XCloseHandle(output_filehandle);
+    BOOL ret = CloseHandle(output_filehandle);
     if(!ret) {
         debugPrint("ERROR: Could not close output file");
     }

--- a/output.h
+++ b/output.h
@@ -9,8 +9,8 @@ void print_test_footer(const char*, const char*, BOOL);
 
 // Real hardware can only display one screen of text at a time. Create an output
 // logfile to contain information for all tests.
-int open_output_file(char*);
-int write_to_output_file(void*, unsigned int);
-int close_output_file();
+void open_output_file(char*);
+int write_to_output_file(void*, DWORD);
+BOOL close_output_file();
 
 #endif

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -4,16 +4,12 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <wchar.h>
+#include <windows.h>
 
 #include "output.h"
 #include "common_assertions.h"
 #include "rtl_assertions.h"
 #include "ke_assertions.h"
-
-// TODO - Move into nxdk
-#define STATUS_INVALID_PARAMETER_2  0xC00000F0
-#define STATUS_BUFFER_OVERFLOW      0x80000005
-#define STATUS_BUFFER_TOO_SMALL     0xC0000023
 
 const char* failed_text = "FAILED";
 const char* passed_text = "PASSED";
@@ -1160,8 +1156,8 @@ void test_RtlMoveMemory(){
     if(src_buffer == NULL) {
         print("ERROR: Could not malloc src_buffer");
     }
-    for(int k=0; k<size; k++){ // we use XGetTickCount as a rand() replacement
-        rnd_letter = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"[(int)XGetTickCount() % 26];
+    for(int k=0; k<size; k++){ // we use GetTickCount as a rand() replacement
+        rnd_letter = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"[(int)GetTickCount() % 26];
         src_buffer[k] = rnd_letter;
     }
 
@@ -1320,8 +1316,8 @@ void test_RtlUpperString(){
     char rnd_letter;
     char rnd_letters[101];
 
-    for(int k=0; k<100; k++){ // we use XGetTickCount as a rand() replacement
-        rnd_letter = "abcdefghijklmnopqrstuvwxyz"[(int)XGetTickCount() % 26];
+    for(int k=0; k<100; k++){ // we use GetTickCount as a rand() replacement
+        rnd_letter = "abcdefghijklmnopqrstuvwxyz"[(int)GetTickCount() % 26];
         rnd_letters[k] = rnd_letter;
     }
     rnd_letters[100] = '\0';

--- a/vector.c
+++ b/vector.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <windows.h>
 #include <hal/xbox.h>
 #include "vector.h"
 #include "output.h"
@@ -20,7 +21,7 @@ void vector_append(vector *vec, int value) {
 int vector_get(vector *vec, int index) {
     if (index >= vec->size || index < 0) {
         print("Error: vector index out of bound\n");
-        XSleep(5000);
+        Sleep(5000);
         XReboot();
     }
     return vec->data[index];


### PR DESCRIPTION
JayFoxRox mentioned in [this](https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/issues/14) issue that we needed to stop using depreciated nxdk functions. I have updated all of the depreciated functions to use the equivalent new functions.