### PR TITLE
Fix relative path usage bug

### DIFF
--- a/main.c
+++ b/main.c
@@ -108,8 +108,8 @@ void main(void){
     pb_show_debug_screen();
 
     vector_init(&tests_to_run);
-    load_conf_file("config.txt");
-    open_output_file("kernel_tests.log");
+    load_conf_file("D:\\config.txt");
+    open_output_file("D:\\kernel_tests.log");
 
     print("Kernel Test Suite");
     run_tests();

--- a/main.c
+++ b/main.c
@@ -12,10 +12,10 @@
 #include "vector.h"
 #include "string_extra.h"
 
-int load_conf_file(char *config_file_path) {
-    print("Trying to open config file: %s", config_file_path);
+int load_conf_file(char *file_path) {
+    print("Trying to open config file: %s", file_path);
     HANDLE handle = CreateFile(
-        config_file_path,
+        file_path,
         GENERIC_READ,
         FILE_SHARE_READ,
         0,
@@ -24,13 +24,13 @@ int load_conf_file(char *config_file_path) {
         NULL
     );
     if(handle == INVALID_HANDLE_VALUE) {
-        print("Could not open config file '%s' for read", config_file_path);
+        print("Could not open config file '%s' for read", file_path);
         return -1;
     }
 
     DWORD file_size = GetFileSize(handle, NULL);
     if(file_size == INVALID_FILE_SIZE) {
-        print("ERROR: Could not get file size for %s", config_file_path);
+        print("ERROR: Could not get file size for %s", file_path);
         return -1;
     }
 

--- a/output.c
+++ b/output.c
@@ -49,15 +49,15 @@ void print_test_footer(
     }
 }
 
-void open_output_file(char* file_name) {
+void open_output_file(char* output_file_path) {
     if(is_emu) {
-        print("Kernel Test Suite: Skipping creating %s because on emulator", file_name);
+        print("Kernel Test Suite: Skipping creating %s because on emulator", output_file_path);
         return;
     }
 
-    debugPrint("Creating file %s", file_name);
+    debugPrint("Creating file %s", output_file_path);
     output_filehandle = CreateFile(
-        file_name,
+        output_file_path,
         GENERIC_WRITE,
         FILE_SHARE_WRITE,
         0,
@@ -67,7 +67,7 @@ void open_output_file(char* file_name) {
     );
 
     if(output_filehandle == INVALID_HANDLE_VALUE) {
-        debugPrint("ERROR: Could not create file %s", file_name);
+        debugPrint("ERROR: Could not create file %s", output_file_path);
     }
 }
 

--- a/output.c
+++ b/output.c
@@ -49,15 +49,15 @@ void print_test_footer(
     }
 }
 
-void open_output_file(char* output_file_path) {
+void open_output_file(char* file_path) {
     if(is_emu) {
-        print("Kernel Test Suite: Skipping creating %s because on emulator", output_file_path);
+        print("Kernel Test Suite: Skipping creating %s because on emulator", file_path);
         return;
     }
 
-    debugPrint("Creating file %s", output_file_path);
+    debugPrint("Creating file %s", file_path);
     output_filehandle = CreateFile(
-        output_file_path,
+        file_path,
         GENERIC_WRITE,
         FILE_SHARE_WRITE,
         0,
@@ -67,7 +67,7 @@ void open_output_file(char* output_file_path) {
     );
 
     if(output_filehandle == INVALID_HANDLE_VALUE) {
-        debugPrint("ERROR: Could not create file %s", output_file_path);
+        debugPrint("ERROR: Could not create file %s", file_path);
     }
 }
 


### PR DESCRIPTION
This is intended to fix the relative path bug issue introduced in https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/pull/61. I already tested this on both my Xbox and with https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/commit/08691c24e17f48e7cecc839fb4a7fd6543d332c5 and I can confirm that they are both able to open `config.txt` and write `kernel_tests.log` files.

Closes https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/issues/14