### PR TITLE
Remove is_emu variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ The configuration file should be called _**"config.txt"**_ and should be placed 
 This is an example of config.txt:
 
 ```
-is_emu=1
-
 tests=1,25,3,F
 ```
 

--- a/global.c
+++ b/global.c
@@ -1,6 +1,3 @@
 #include "vector.h"
 
-// Until the config.txt file can be loaded on the emulator, set emu by default
-// and use the config.txt file to disable the flag on real hardware
-int is_emu = 1;
 vector tests_to_run;

--- a/global.h
+++ b/global.h
@@ -5,7 +5,6 @@
 
 #define NV2A_MMIO_BASE 0xFD000000
 
-extern int is_emu;
 extern vector tests_to_run;
 
 #endif

--- a/main.c
+++ b/main.c
@@ -53,9 +53,6 @@ int load_conf_file(char *file_path) {
     char *rest = buffer;
     while ((line = strtok_r(rest, "\n", &rest))){
         char *current_key = strtok(line, "=");
-        if(strcmp("is_emu", current_key) == 0){
-            is_emu = strtol(strtok(NULL, "\n"), NULL, 16);
-        }
         if(strcmp("tests", current_key) == 0){
             char *current_test;
             char *tests = strtok(NULL, "\n");
@@ -70,12 +67,6 @@ int load_conf_file(char *file_path) {
 }
 
 static void run_tests() {
-    if(is_emu) {
-        print("Running tests in emulator mode");
-    }
-    else {
-        print("Running tests in real hardware mode");
-    }
     if(tests_to_run.size == 0) {
         print("No Specific tests specified. Running all tests (Single Pass).");
         print("-------------------------------------------------------------");

--- a/output.c
+++ b/output.c
@@ -50,11 +50,6 @@ void print_test_footer(
 }
 
 void open_output_file(char* file_path) {
-    if(is_emu) {
-        print("Kernel Test Suite: Skipping creating %s because on emulator", file_path);
-        return;
-    }
-
     debugPrint("Creating file %s", file_path);
     output_filehandle = CreateFile(
         file_path,
@@ -72,10 +67,6 @@ void open_output_file(char* file_path) {
 }
 
 int write_to_output_file(void* data_to_print, DWORD num_bytes_to_print) {
-    if(is_emu) {
-        return 0;
-    }
-
     DWORD bytes_written;
     BOOL ret = WriteFile(
         output_filehandle,
@@ -96,9 +87,6 @@ int write_to_output_file(void* data_to_print, DWORD num_bytes_to_print) {
 }
 
 BOOL close_output_file() {
-    if(is_emu) {
-        return 0;
-    }
     BOOL ret = CloseHandle(output_filehandle);
     if(!ret) {
         debugPrint("ERROR: Could not close output file");


### PR DESCRIPTION
This changes were tested on both my Xbox and with https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/commit/08691c24e17f48e7cecc839fb4a7fd6543d332c5. I used two `config.txt` files: the first was empty (thus specifying no tests) and the other specified tests  1, 25, 3, F. Both were successful, that is they ran all tests and ran only test 1 (because tests 25, 3 and F don’t exist/are disabled). Based on this, the `is_emu` variable is no longer needed and this PR removes it.