### PR TITLE
Fix missing randomness in some Rtl tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The configuration file should be called _**"config.txt"**_ and should be placed 
 This is an example of config.txt:
 
 ```
+seed=5
+
 tests=1,25,3,F
 ```
 

--- a/global.c
+++ b/global.c
@@ -1,3 +1,4 @@
 #include "vector.h"
 
+unsigned int seed = 0;
 vector tests_to_run;

--- a/global.h
+++ b/global.h
@@ -5,6 +5,7 @@
 
 #define NV2A_MMIO_BASE 0xFD000000
 
+extern unsigned int seed;
 extern vector tests_to_run;
 
 #endif

--- a/main.c
+++ b/main.c
@@ -53,6 +53,9 @@ int load_conf_file(char *file_path) {
     char *rest = buffer;
     while ((line = strtok_r(rest, "\n", &rest))){
         char *current_key = strtok(line, "=");
+        if(strcmp("seed", current_key) == 0){
+            seed = strtoul(strtok(NULL, "\n"), NULL, 16);
+        }
         if(strcmp("tests", current_key) == 0){
             char *current_test;
             char *tests = strtok(NULL, "\n");
@@ -67,6 +70,7 @@ int load_conf_file(char *file_path) {
 }
 
 static void run_tests() {
+    print("Random seed used is %u", seed);
     if(tests_to_run.size == 0) {
         print("No Specific tests specified. Running all tests (Single Pass).");
         print("-------------------------------------------------------------");

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -6,6 +6,7 @@
 #include <wchar.h>
 #include <windows.h>
 
+#include "global.h"
 #include "output.h"
 #include "common_assertions.h"
 #include "rtl_assertions.h"
@@ -1156,8 +1157,9 @@ void test_RtlMoveMemory(){
     if(src_buffer == NULL) {
         print("ERROR: Could not malloc src_buffer");
     }
-    for(int k=0; k<size; k++){ // we use GetTickCount as a rand() replacement
-        rnd_letter = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"[(int)GetTickCount() % 26];
+    srand(seed);
+    for(int k=0; k<size; k++){
+        rnd_letter = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"[rand() % 26];
         src_buffer[k] = rnd_letter;
     }
 
@@ -1316,8 +1318,9 @@ void test_RtlUpperString(){
     char rnd_letter;
     char rnd_letters[101];
 
-    for(int k=0; k<100; k++){ // we use GetTickCount as a rand() replacement
-        rnd_letter = "abcdefghijklmnopqrstuvwxyz"[(int)GetTickCount() % 26];
+    srand(seed);
+    for(int k=0; k<100; k++){
+        rnd_letter = "abcdefghijklmnopqrstuvwxyz"[rand() % 26];
         rnd_letters[k] = rnd_letter;
     }
     rnd_letters[100] = '\0';


### PR DESCRIPTION
Closes https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/issues/62. First I tested on the Xbox by adding the following debug code (which was removed before submitting this PR) after the loop which selects the letters:

```
for(int k=0; k<100; k++){
    print("rnd_letters[%d] = %c", k, rnd_letters[k]);
}
```
<details>
<summary>Before PR</summary>

```
rnd_letters[0] = s
rnd_letters[1] = s
rnd_letters[2] = s
rnd_letters[3] = s
rnd_letters[4] = s
rnd_letters[5] = s
rnd_letters[6] = s
rnd_letters[7] = s
rnd_letters[8] = s
rnd_letters[9] = s
rnd_letters[10] = s
rnd_letters[11] = s
rnd_letters[12] = s
rnd_letters[13] = s
rnd_letters[14] = s
rnd_letters[15] = s
rnd_letters[16] = s
rnd_letters[17] = s
rnd_letters[18] = s
rnd_letters[19] = s
rnd_letters[20] = s
rnd_letters[21] = s
rnd_letters[22] = s
rnd_letters[23] = s
rnd_letters[24] = s
rnd_letters[25] = s
rnd_letters[26] = s
rnd_letters[27] = s
rnd_letters[28] = s
rnd_letters[29] = s
rnd_letters[30] = s
rnd_letters[31] = s
rnd_letters[32] = s
rnd_letters[33] = s
rnd_letters[34] = s
rnd_letters[35] = s
rnd_letters[36] = s
rnd_letters[37] = s
rnd_letters[38] = s
rnd_letters[39] = s
rnd_letters[40] = s
rnd_letters[41] = s
rnd_letters[42] = s
rnd_letters[43] = s
rnd_letters[44] = s
rnd_letters[45] = s
rnd_letters[46] = s
rnd_letters[47] = s
rnd_letters[48] = s
rnd_letters[49] = s
rnd_letters[50] = s
rnd_letters[51] = s
rnd_letters[52] = s
rnd_letters[53] = s
rnd_letters[54] = s
rnd_letters[55] = s
rnd_letters[56] = s
rnd_letters[57] = s
rnd_letters[58] = s
rnd_letters[59] = s
rnd_letters[60] = s
rnd_letters[61] = s
rnd_letters[62] = s
rnd_letters[63] = s
rnd_letters[64] = s
rnd_letters[65] = s
rnd_letters[66] = s
rnd_letters[67] = s
rnd_letters[68] = s
rnd_letters[69] = s
rnd_letters[70] = s
rnd_letters[71] = s
rnd_letters[72] = s
rnd_letters[73] = s
rnd_letters[74] = s
rnd_letters[75] = s
rnd_letters[76] = s
rnd_letters[77] = s
rnd_letters[78] = s
rnd_letters[79] = s
rnd_letters[80] = s
rnd_letters[81] = s
rnd_letters[82] = s
rnd_letters[83] = s
rnd_letters[84] = s
rnd_letters[85] = s
rnd_letters[86] = s
rnd_letters[87] = s
rnd_letters[88] = s
rnd_letters[89] = s
rnd_letters[90] = s
rnd_letters[91] = s
rnd_letters[92] = s
rnd_letters[93] = s
rnd_letters[94] = s
rnd_letters[95] = s
rnd_letters[96] = s
rnd_letters[97] = s
rnd_letters[98] = s
rnd_letters[99] = s
```
</details>

<details>
<summary>After PR</summary>

```
rnd_letters[0] = h
rnd_letters[1] = w
rnd_letters[2] = x
rnd_letters[3] = d
rnd_letters[4] = e
rnd_letters[5] = c
rnd_letters[6] = f
rnd_letters[7] = v
rnd_letters[8] = l
rnd_letters[9] = x
rnd_letters[10] = a
rnd_letters[11] = d
rnd_letters[12] = w
rnd_letters[13] = i
rnd_letters[14] = y
rnd_letters[15] = j
rnd_letters[16] = d
rnd_letters[17] = f
rnd_letters[18] = o
rnd_letters[19] = h
rnd_letters[20] = a
rnd_letters[21] = t
rnd_letters[22] = u
rnd_letters[23] = s
rnd_letters[24] = z
rnd_letters[25] = z
rnd_letters[26] = z
rnd_letters[27] = d
rnd_letters[28] = o
rnd_letters[29] = q
rnd_letters[30] = s
rnd_letters[31] = a
rnd_letters[32] = m
rnd_letters[33] = t
rnd_letters[34] = c
rnd_letters[35] = q
rnd_letters[36] = r
rnd_letters[37] = k
rnd_letters[38] = q
rnd_letters[39] = f
rnd_letters[40] = j
rnd_letters[41] = h
rnd_letters[42] = j
rnd_letters[43] = w
rnd_letters[44] = d
rnd_letters[45] = p
rnd_letters[46] = q
rnd_letters[47] = d
rnd_letters[48] = u
rnd_letters[49] = u
rnd_letters[50] = r
rnd_letters[51] = c
rnd_letters[52] = d
rnd_letters[53] = b
rnd_letters[54] = r
rnd_letters[55] = k
rnd_letters[56] = k
rnd_letters[57] = v
rnd_letters[58] = k
rnd_letters[59] = t
rnd_letters[60] = r
rnd_letters[61] = x
rnd_letters[62] = b
rnd_letters[63] = z
rnd_letters[64] = v
rnd_letters[65] = e
rnd_letters[66] = w
rnd_letters[67] = o
rnd_letters[68] = z
rnd_letters[69] = e
rnd_letters[70] = x
rnd_letters[71] = c
rnd_letters[72] = w
rnd_letters[73] = d
rnd_letters[74] = h
rnd_letters[75] = f
rnd_letters[76] = t
rnd_letters[77] = k
rnd_letters[78] = i
rnd_letters[79] = m
rnd_letters[80] = o
rnd_letters[81] = d
rnd_letters[82] = x
rnd_letters[83] = p
rnd_letters[84] = h
rnd_letters[85] = a
rnd_letters[86] = t
rnd_letters[87] = d
rnd_letters[88] = x
rnd_letters[89] = o
rnd_letters[90] = j
rnd_letters[91] = p
rnd_letters[92] = o
rnd_letters[93] = t
rnd_letters[94] = i
rnd_letters[95] = p
rnd_letters[96] = s
rnd_letters[97] = l
rnd_letters[98] = m
rnd_letters[99] = y
```
</details>

The previous code was indeed selecting the same letter, thus confirming the issue. After the fix, pseudo-random letters are selected, as desired. I repeated the test with https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/commit/08691c24e17f48e7cecc839fb4a7fd6543d332c5 and got the same behaviour as well. Also, the `kernel_tests.log` file reported the `RtlUpperString` test as successful on both the Xbox and Cxbx-R so this didn’t break the test either. Finally, I applied the same fix to the `RtlMoveMemory` test, since I noticed it used the same code to select the random letters. I only tested that with Cxbx-R however, where I got the same result of above (that is, it selects pseudo-random letters).

PS: the results of above were obtained with a seed based on `time(NULL)`, and thus not constant like https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/issues/62 suggested. This was rectified in a later commit, but the seed constness was only tested and confirmed with Cxbx-R.
