### PR TITLE
Add tests for IoCreateSymbolicLink and IoDeleteSymbolicLink

### DIFF
--- a/io_tests.c
+++ b/io_tests.c
@@ -1,3 +1,9 @@
+#include <xboxkrnl/xboxkrnl.h>
+#include <windows.h>
+
+#include "output.h"
+#include "common_assertions.h"
+
 void test_IoAllocateIrp(){
     /* FIXME: This is a stub! implement this function! */
 }
@@ -31,7 +37,43 @@ void test_IoCreateFile(){
 }
 
 void test_IoCreateSymbolicLink(){
-    /* FIXME: This is a stub! implement this function! */
+    const char* func_num = "0x0043";
+    const char* func_name = "IoCreateSymbolicLink";
+    BOOL tests_passed = 1;
+    print_test_header(func_num, func_name);
+
+    ANSI_STRING symlink_str, symlink_bad_str, device_str, device_w_slash_str, device_bad_path_nonexistent_str;
+    RtlInitAnsiString(&symlink_str, "\\xkts");
+    RtlInitAnsiString(&symlink_bad_str, "\\xkts\\bad_symlink");
+    RtlInitAnsiString(&device_str, "\\Device\\Harddisk0\\Partition5");
+    RtlInitAnsiString(&device_w_slash_str, "\\Device\\Harddisk0\\Partition5\\");
+    RtlInitAnsiString(&device_bad_path_nonexistent_str, "\\Device\\Harddisk0\\Partition5\\xkts_nonexistent");
+    NTSTATUS result;
+
+    result = IoCreateSymbolicLink(&symlink_str, &device_str);
+    tests_passed &= assert_NTSTATUS(result, STATUS_SUCCESS, func_name);
+
+    // Do not delete symbolic link yet in order to trigger object name collision error.
+    result = IoCreateSymbolicLink(&symlink_str, &device_str);
+    tests_passed &= assert_NTSTATUS(result, STATUS_OBJECT_NAME_COLLISION, func_name);
+
+    IoDeleteSymbolicLink(&symlink_str);
+
+    result = IoCreateSymbolicLink(&symlink_str, &device_w_slash_str);
+    tests_passed &= assert_NTSTATUS(result, STATUS_SUCCESS, func_name);
+
+    IoDeleteSymbolicLink(&symlink_str);
+
+    result = IoCreateSymbolicLink(&symlink_str, &device_bad_path_nonexistent_str);
+    tests_passed &= assert_NTSTATUS(result, STATUS_OBJECT_NAME_NOT_FOUND, func_name);
+
+    result = IoCreateSymbolicLink(&symlink_bad_str, &device_str);
+    tests_passed &= assert_NTSTATUS(result, STATUS_OBJECT_PATH_NOT_FOUND, func_name);
+
+    result = IoCreateSymbolicLink(&device_bad_path_nonexistent_str, &device_str);
+    tests_passed &= assert_NTSTATUS(result, STATUS_OBJECT_PATH_NOT_FOUND, func_name);
+
+    print_test_footer(func_num, func_name, tests_passed);
 }
 
 void test_IoDeleteDevice(){
@@ -39,7 +81,25 @@ void test_IoDeleteDevice(){
 }
 
 void test_IoDeleteSymbolicLink(){
-    /* FIXME: This is a stub! implement this function! */
+    const char* func_num = "0x0045";
+    const char* func_name = "IoDeleteSymbolicLink";
+    BOOL tests_passed = 1;
+    print_test_header(func_num, func_name);
+
+    ANSI_STRING symlink_str, device_str;
+    RtlInitAnsiString(&symlink_str, "\\xkts");
+    RtlInitAnsiString(&device_str, "\\Device\\Harddisk0\\Partition5");
+    NTSTATUS result;
+
+    IoCreateSymbolicLink(&symlink_str, &device_str);
+
+    result = IoDeleteSymbolicLink(&symlink_str);
+    tests_passed &= assert_NTSTATUS(result, STATUS_SUCCESS, func_name);
+
+    result = IoDeleteSymbolicLink(&symlink_str);
+    tests_passed &= assert_NTSTATUS(result, STATUS_OBJECT_NAME_NOT_FOUND, func_name);
+
+    print_test_footer(func_num, func_name, tests_passed);
 }
 
 void test_IoDeviceObjectType(){

--- a/io_tests.c
+++ b/io_tests.c
@@ -36,20 +36,36 @@ void test_IoCreateFile(){
     /* FIXME: This is a stub! implement this function! */
 }
 
+
+/* possible missing
+- STATUS_INSUFFICIENT_RESOURCES
+- STATUS_OBJECT_NAME_EXISTS
+- STATUS_OBJECT_TYPE_MISMATCH
+*/
 void test_IoCreateSymbolicLink(){
     const char* func_num = "0x0043";
     const char* func_name = "IoCreateSymbolicLink";
     BOOL tests_passed = 1;
     print_test_header(func_num, func_name);
 
-    ANSI_STRING symlink_str, symlink_bad_str, device_str, device_w_slash_str, device_bad_path_nonexistent_str;
+    ANSI_STRING null_str, blank_str, symlink_str, device_str,
+        symlink_no_slash_str, symlink_bad_str, device_w_slash_str,
+        device_no_slash_str, device_bad_path_nonexistent_str,
+        device_bad_path_invalid_str;
+    RtlInitAnsiString(&null_str, NULL);
+    RtlInitAnsiString(&blank_str, "");
     RtlInitAnsiString(&symlink_str, "\\xkts");
+    RtlInitAnsiString(&symlink_no_slash_str, "xkts");
     RtlInitAnsiString(&symlink_bad_str, "\\xkts\\bad_symlink");
     RtlInitAnsiString(&device_str, "\\Device\\Harddisk0\\Partition5");
     RtlInitAnsiString(&device_w_slash_str, "\\Device\\Harddisk0\\Partition5\\");
+    RtlInitAnsiString(&device_no_slash_str, "Device\\Harddisk0\\Partition5");
     RtlInitAnsiString(&device_bad_path_nonexistent_str, "\\Device\\Harddisk0\\Partition5\\xkts_nonexistent");
+    RtlInitAnsiString(&device_bad_path_invalid_str, "\\Device\\Hardd:sk0\\Partition5");
+
     NTSTATUS result;
 
+    // First part of the test is ensure we are able to make symbolic link.
     result = IoCreateSymbolicLink(&symlink_str, &device_str);
     tests_passed &= assert_NTSTATUS(result, STATUS_SUCCESS, func_name);
 
@@ -57,21 +73,58 @@ void test_IoCreateSymbolicLink(){
     result = IoCreateSymbolicLink(&symlink_str, &device_str);
     tests_passed &= assert_NTSTATUS(result, STATUS_OBJECT_NAME_COLLISION, func_name);
 
+    // Now we can delete symbolic link for next part of various tests.
     IoDeleteSymbolicLink(&symlink_str);
 
-    result = IoCreateSymbolicLink(&symlink_str, &device_w_slash_str);
-    tests_passed &= assert_NTSTATUS(result, STATUS_SUCCESS, func_name);
+    // Finally, do various of tests which may could be either successful or failure
+    // with cleanup inline to ensure next test is expected to have correct result.
+    typedef struct {
+        PSTRING pStr;
+        NTSTATUS expected_result;
+    } str_array;
 
-    IoDeleteSymbolicLink(&symlink_str);
+    str_array symlink_test_str[] = {
+        { NULL, STATUS_SUCCESS },
+        { &null_str, STATUS_OBJECT_NAME_INVALID },
+        { &blank_str, STATUS_OBJECT_NAME_INVALID },
+        { &symlink_no_slash_str, STATUS_OBJECT_NAME_INVALID },
+        { &symlink_bad_str, STATUS_OBJECT_PATH_NOT_FOUND },
+        { &device_str, STATUS_OBJECT_PATH_NOT_FOUND },
+        { &device_bad_path_nonexistent_str, STATUS_OBJECT_PATH_NOT_FOUND },
+    };
+    size_t symlink_test_size = sizeof(symlink_test_str)/sizeof(symlink_test_str[0]);
 
-    result = IoCreateSymbolicLink(&symlink_str, &device_bad_path_nonexistent_str);
-    tests_passed &= assert_NTSTATUS(result, STATUS_OBJECT_NAME_NOT_FOUND, func_name);
+    str_array device_test_str[] = {
+        { &null_str, STATUS_INVALID_PARAMETER },
+        { &blank_str, STATUS_INVALID_PARAMETER },
+        { &device_w_slash_str, STATUS_SUCCESS },
+        { &device_no_slash_str, STATUS_INVALID_PARAMETER },
+        { &device_bad_path_nonexistent_str, STATUS_OBJECT_NAME_NOT_FOUND },
+        { &device_bad_path_invalid_str, STATUS_INVALID_PARAMETER },
+        { &symlink_str, STATUS_INVALID_PARAMETER },
+        { &symlink_no_slash_str, STATUS_INVALID_PARAMETER },
+    };
+    size_t device_test_str_size = sizeof(device_test_str)/sizeof(device_test_str[0]);
 
-    result = IoCreateSymbolicLink(&symlink_bad_str, &device_str);
-    tests_passed &= assert_NTSTATUS(result, STATUS_OBJECT_PATH_NOT_FOUND, func_name);
+    print("  Running tests for symbolic link inputs");
+    for (unsigned i = 0; i < symlink_test_size; i++) {
+        result = IoCreateSymbolicLink(symlink_test_str[i].pStr, &device_str);
+        if (result == STATUS_SUCCESS) {
+            IoDeleteSymbolicLink(symlink_test_str[i].pStr);
+        }
 
-    result = IoCreateSymbolicLink(&device_bad_path_nonexistent_str, &device_str);
-    tests_passed &= assert_NTSTATUS(result, STATUS_OBJECT_PATH_NOT_FOUND, func_name);
+        tests_passed &= assert_NTSTATUS(result, symlink_test_str[i].expected_result, func_name);
+    }
+
+    print("  Running tests for device inputs");
+    for (unsigned i = 0; i < device_test_str_size; i++) {
+        result = IoCreateSymbolicLink(&symlink_str, device_test_str[i].pStr);
+        if (result == STATUS_SUCCESS) {
+            IoDeleteSymbolicLink(&symlink_str);
+        }
+
+        tests_passed &= assert_NTSTATUS(result, device_test_str[i].expected_result, func_name);
+    }
 
     print_test_footer(func_num, func_name, tests_passed);
 }
@@ -86,9 +139,11 @@ void test_IoDeleteSymbolicLink(){
     BOOL tests_passed = 1;
     print_test_header(func_num, func_name);
 
-    ANSI_STRING symlink_str, device_str;
+    ANSI_STRING symlink_str, device_str, null_str, blank_str;
     RtlInitAnsiString(&symlink_str, "\\xkts");
     RtlInitAnsiString(&device_str, "\\Device\\Harddisk0\\Partition5");
+    RtlInitAnsiString(&null_str, NULL);
+    RtlInitAnsiString(&blank_str, "");
     NTSTATUS result;
 
     IoCreateSymbolicLink(&symlink_str, &device_str);
@@ -98,6 +153,15 @@ void test_IoDeleteSymbolicLink(){
 
     result = IoDeleteSymbolicLink(&symlink_str);
     tests_passed &= assert_NTSTATUS(result, STATUS_OBJECT_NAME_NOT_FOUND, func_name);
+
+    result = IoDeleteSymbolicLink(&null_str);
+    tests_passed &= assert_NTSTATUS(result, STATUS_OBJECT_NAME_INVALID, func_name);
+
+    result = IoDeleteSymbolicLink(&blank_str);
+    tests_passed &= assert_NTSTATUS(result, STATUS_OBJECT_NAME_INVALID, func_name);
+
+    result = IoDeleteSymbolicLink(NULL);
+    tests_passed &= assert_NTSTATUS(result, STATUS_OBJECT_NAME_INVALID, func_name);
 
     print_test_footer(func_num, func_name, tests_passed);
 }


### PR DESCRIPTION
**Draft pull request due to missing status defines in nxdk's repo.**

---

Add tests for IoCreateSymbolicLink and IoDeleteSymbolicLink against hardware to return expected result.
**From hardware test: (updated)**
```
0x0043 - IoCreateSymbolicLink: Tests Starting
  Function 'IoCreateSymbolicLink' returned 0x0 as expected
  Function 'IoCreateSymbolicLink' returned 0xc0000035 as expected
  Running tests for symbolic link inputs
  Function 'IoCreateSymbolicLink' returned 0x0 as expected
  Function 'IoCreateSymbolicLink' returned 0xc0000033 as expected
  Function 'IoCreateSymbolicLink' returned 0xc0000033 as expected
  Function 'IoCreateSymbolicLink' returned 0xc0000033 as expected
  Function 'IoCreateSymbolicLink' returned 0xc000003a as expected
  Function 'IoCreateSymbolicLink' returned 0xc000003a as expected
  Function 'IoCreateSymbolicLink' returned 0xc000003a as expected
  Running tests for device inputs
  Function 'IoCreateSymbolicLink' returned 0xc000000d as expected
  Function 'IoCreateSymbolicLink' returned 0xc000000d as expected
  Function 'IoCreateSymbolicLink' returned 0x0 as expected
  Function 'IoCreateSymbolicLink' returned 0xc000000d as expected
  Function 'IoCreateSymbolicLink' returned 0xc0000034 as expected
  Function 'IoCreateSymbolicLink' returned 0xc000000d as expected
  Function 'IoCreateSymbolicLink' returned 0xc000000d as expected
  Function 'IoCreateSymbolicLink' returned 0xc000000d as expected
0x0043 - IoCreateSymbolicLink: All tests PASSED
0x0045 - IoDeleteSymbolicLink: Tests Starting
  Function 'IoDeleteSymbolicLink' returned 0x0 as expected
  Function 'IoDeleteSymbolicLink' returned 0xc0000034 as expected
  Function 'IoDeleteSymbolicLink' returned 0xc0000033 as expected
  Function 'IoDeleteSymbolicLink' returned 0xc0000033 as expected
  Function 'IoDeleteSymbolicLink' returned 0xc0000033 as expected
0x0045 - IoDeleteSymbolicLink: All tests PASSED
```

Cxbx-Reloaded does not respect expected return result, so it needs some work to make corrections.