### PR TITLE
Add test for RtlUnicodeStringToAnsiString function

### DIFF
--- a/rtl_assertions.c
+++ b/rtl_assertions.c
@@ -36,8 +36,8 @@ BOOL assert_ansi_string(
         GEN_CHECK(string->Buffer, NULL, "Buffer is NULL");
     }
     else {
-        int result = strncmp(string->Buffer, expected_Buffer, expected_MaximumLength);
-        GEN_CHECK(result, 0, "strcmp result of Buffer");
+        int result = memcmp(string->Buffer, expected_Buffer, expected_Length);
+        GEN_CHECK(result, 0, "memcmp result of Buffer");
         if(result) {
             print("  Buffer = %s, expected_Buffer = %s", string->Buffer, expected_Buffer);
         }
@@ -62,8 +62,8 @@ static BOOL assert_unicode_string(
         GEN_CHECK(string->Buffer, NULL, "Buffer is null");
     }
     else {
-        int result = wcscmp(string->Buffer, expected_Buffer);
-        GEN_CHECK(result, 0, "wcscmp result of Buffer");
+        int result = memcmp(string->Buffer, expected_Buffer, expected_Length);
+        GEN_CHECK(result, 0, "memcmp result of Buffer");
     }
 
     ASSERT_FOOTER(test_name)

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -1289,6 +1289,7 @@ void test_RtlUnicodeStringToAnsiString(){
         ansi_text,
         "Convert partial unicode to ansi string."
     );
+    memset(ansi_string.Buffer, 0, ansi_string.MaximumLength);
 
     // Finally, try modify member variables to get any other result come back as invalid.
 
@@ -1306,6 +1307,7 @@ void test_RtlUnicodeStringToAnsiString(){
         ansi_text,
         "Convert unicode (up by one length) to limited ansi string."
     );
+    memset(ansi_string.Buffer, 0, ansi_string.MaximumLength);
 
     // When default behavior is working, try override to use whole unicode text.
     unicode_string.MaximumLength = sizeof(unicode_text);
@@ -1322,6 +1324,7 @@ void test_RtlUnicodeStringToAnsiString(){
         ansi_text,
         "Convert max unicode to limited ansi string."
     );
+    memset(ansi_string.Buffer, 0, ansi_string.MaximumLength);
 
     // Now let's update ansi string's length to the max.
     ansi_string.MaximumLength = sizeof(ansi_buffer);
@@ -1335,6 +1338,7 @@ void test_RtlUnicodeStringToAnsiString(){
         ansi_text,
         "Convert full unicode to ansi string."
     );
+    memset(ansi_string.Buffer, 0, ansi_string.MaximumLength);
 
     ansi_string.MaximumLength = 0;
     result = RtlUnicodeStringToAnsiString(&ansi_string, &unicode_string, 0);
@@ -1360,6 +1364,7 @@ void test_RtlUnicodeStringToAnsiString(){
         ansi_text_max,
         "Unicode to max ansi string."
     );
+    memset(ansi_string.Buffer, 0, ansi_string.MaximumLength);
 
     // Now increase unicode string length to max.
     // We can't multiply by size of WCHAR due to uint16_t's max size
@@ -1375,6 +1380,7 @@ void test_RtlUnicodeStringToAnsiString(){
         ansi_text_max,
         "Max unicode to max ansi string."
     );
+    memset(ansi_string.Buffer, 0, ansi_string.MaximumLength);
 
     // Free up our allocated buffers
     ExFreePool(ansi_text_max);

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -1239,7 +1239,133 @@ void test_RtlUlongByteSwap(){
 }
 
 void test_RtlUnicodeStringToAnsiString(){
-    /* FIXME: This is a stub! implement this function! */
+    const char* func_num = "0x0134";
+    const char* func_name = "RtlUnicodeStringToAnsiString";
+    BOOL tests_passed = 1;
+    print_test_header(func_num, func_name);
+
+    UNICODE_STRING unicode_string;
+    WCHAR unicode_text[] = L"Xbox\x0100\xFFFF\0Xbox\x0255";
+    char ansi_text[] = "Xbox??\0Xbox?";
+    char ansi_buffer[sizeof(ansi_text)];
+    ANSI_STRING ansi_string;
+    const BOOL alloc_buffer = 1;
+
+    // Test if default behavior is working as intended.
+    RtlInitUnicodeString(&unicode_string, unicode_text);
+
+    tests_passed &= assert_unicode_string(
+        &unicode_string,
+        wcslen(unicode_text) * sizeof(WCHAR),
+        (wcslen(unicode_text) + 1) * sizeof(WCHAR),
+        unicode_text,
+        "Initialize unicode string."
+    );
+
+    NTSTATUS result = RtlUnicodeStringToAnsiString(&ansi_string, &unicode_string, alloc_buffer);
+
+    tests_passed &= assert_NTSTATUS(result, STATUS_SUCCESS, func_name);
+
+    tests_passed &= assert_ansi_string(
+        &ansi_string,
+        wcslen(unicode_text),
+        wcslen(unicode_text) + 1,
+        ansi_text,
+        "Convert partial unicode to ansi string (alloc)."
+    );
+
+    if (result == STATUS_SUCCESS) {
+        RtlFreeAnsiString(&ansi_string);
+    }
+
+    ansi_string.Length = wcslen(unicode_text);
+    ansi_string.MaximumLength = ansi_string.Length + 1;
+    ansi_string.Buffer = ansi_buffer;
+    result = RtlUnicodeStringToAnsiString(&ansi_string, &unicode_string, 0);
+
+    tests_passed &= assert_NTSTATUS(result, STATUS_SUCCESS, func_name);
+
+    tests_passed &= assert_ansi_string(
+        &ansi_string,
+        wcslen(unicode_text),
+        wcslen(unicode_text) + 1,
+        ansi_text,
+        "Convert partial unicode to ansi string."
+    );
+
+    // When default behavior is working, try override to use whole unicode text.
+    unicode_string.MaximumLength = sizeof(unicode_text);
+    unicode_string.Length = unicode_string.MaximumLength - 1 * sizeof(WCHAR);
+
+    // Since we didn't update ansi string, we should trigger buffer overflow status.
+    result = RtlUnicodeStringToAnsiString(&ansi_string, &unicode_string, 0);
+    tests_passed &= assert_NTSTATUS(result, STATUS_BUFFER_OVERFLOW, func_name);
+
+    // Now let's update ansi string's length to the max.
+    ansi_string.MaximumLength = sizeof(ansi_buffer);
+    ansi_string.Length = ansi_string.MaximumLength - 1;
+    result = RtlUnicodeStringToAnsiString(&ansi_string, &unicode_string, 0);
+
+    tests_passed &= assert_NTSTATUS(result, STATUS_SUCCESS, func_name);
+
+    tests_passed &= assert_ansi_string(
+        &ansi_string,
+        sizeof(unicode_text) / sizeof(WCHAR) - 1,
+        sizeof(unicode_text) / sizeof(WCHAR),
+        ansi_text,
+        "Convert full unicode to ansi string."
+    );
+
+    // Finally, try modify member variables to get any other result come back as invalid.
+
+    ansi_string.MaximumLength = 0;
+    result = RtlUnicodeStringToAnsiString(&ansi_string, &unicode_string, 0);
+    tests_passed &= assert_NTSTATUS(result, STATUS_BUFFER_OVERFLOW, func_name);
+
+    // Allocate unicode and ansi strings for attempt to maxed out.
+    WCHAR* unicode_text_max = ExAllocatePoolWithTag(UINT16_MAX, 'grtS');
+    memcpy(unicode_text_max, unicode_text, sizeof(unicode_text));
+    char* ansi_text_max = ExAllocatePoolWithTag(UINT16_MAX, 'grtS');
+    memcpy(ansi_text_max, ansi_text, sizeof(ansi_text));
+
+    // Increase ansi string length to max.
+    ansi_string.MaximumLength = UINT16_MAX;
+    ansi_string.Length = UINT16_MAX;
+    ansi_string.Buffer = ansi_text_max;
+    result = RtlUnicodeStringToAnsiString(&ansi_string, &unicode_string, 0);
+
+    tests_passed &= assert_NTSTATUS(result, STATUS_SUCCESS, func_name);
+
+    tests_passed &= assert_ansi_string(
+        &ansi_string,
+        sizeof(unicode_text) / sizeof(WCHAR) - 1,
+        UINT16_MAX,
+        ansi_text_max,
+        "Unicode to max ansi string."
+    );
+
+    // Now increase unicode string length to max.
+    // We can't multiply by size of WCHAR due to uint16_t's max size
+    unicode_string.MaximumLength = UINT16_MAX;
+    unicode_string.Length = UINT16_MAX;
+    unicode_string.Buffer = unicode_text_max;
+    result = RtlUnicodeStringToAnsiString(&ansi_string, &unicode_string, 0);
+
+    tests_passed &= assert_NTSTATUS(result, STATUS_SUCCESS, func_name);
+
+    tests_passed &= assert_ansi_string(
+        &ansi_string,
+        (UINT16_MAX-1) / sizeof(WCHAR),
+        UINT16_MAX,
+        ansi_text_max,
+        "Max unicode to max ansi string."
+    );
+
+    // Free up buffers
+    ExFreePool(ansi_text_max);
+    ExFreePool(unicode_text_max);
+
+    print_test_footer(func_num, func_name, tests_passed);
 }
 
 void test_RtlUnicodeStringToInteger(){


### PR DESCRIPTION
After found out about DoA 1 Ultimate's crash for create a profile. I start making the test for any possibility success and failure outcome. In the process, I found some faults in Cxbx-Reloaded's implemention for RtlUnicodeStringToAnsiString function. Plus kernel test suite with string comparsion being checked for null termation when should had check the whole length instead. With this pull request's implemention and a fix for comparsion. It is working as intended base on hardware result (see below).

xbox hardware test: (updated)
```
0x0134 - RtlUnicodeStringToAnsiString: Tests Starting
  Test 'Initialize unicode string.' PASSED
  Function 'RtlUnicodeStringToAnsiString' returned 0x0 as expected
  Test 'Convert partial unicode to ansi string (alloc).' PASSED
  Function 'RtlUnicodeStringToAnsiString' returned 0x0 as expected
  Test 'Convert partial unicode to ansi string.' PASSED
  Function 'RtlUnicodeStringToAnsiString' returned 0x80000005 as expected
  Test 'Convert unicode (up by one length) to limited ansi string.' PASSED
  Function 'RtlUnicodeStringToAnsiString' returned 0x80000005 as expected
  Test 'Convert max unicode to limited ansi string.' PASSED
  Function 'RtlUnicodeStringToAnsiString' returned 0x0 as expected
  Test 'Convert full unicode to ansi string.' PASSED
  Function 'RtlUnicodeStringToAnsiString' returned 0x80000005 as expected
  Function 'RtlUnicodeStringToAnsiString' returned 0x0 as expected
  Test 'Unicode to max ansi string.' PASSED
  Function 'RtlUnicodeStringToAnsiString' returned 0x0 as expected
  Test 'Max unicode to max ansi string.' PASSED
0x0134 - RtlUnicodeStringToAnsiString: All tests PASSED
```

---

This test will produce a crash on Cxbx-Reloaded, pull request is being made to solve the issue.