### PR TITLE
Fix GitHub CI Build Issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,9 @@ jobs:
           sudo apt-get -y install lld llvm
       - name: Build
         working-directory: ${{ steps.xkts.outputs.dir }}
-        run: make -j$(nproc)
+        run: |
+          eval $(../../bin/activate -s) # setup nxdk variables into environment
+          make -j$(nproc)
       - name: Set artifact + release parameters
         id: parameters
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
 XBE_TITLE=kernel_test_suite
 SRCS = $(wildcard $(CURDIR)/*.c)
-NXDK_DIR = $(CURDIR)/../..
 include $(NXDK_DIR)/Makefile


### PR DESCRIPTION
resolve #73 for `make: nxdk-cc: Command not found` error.

~~Plus add `export` to Makefile's NXDK_DIR variable to environment support. In order for able have NXDK's includes recognized.~~

---

**EDIT:** Turns out NXDK has change to new build system. Using `eval $(../../bin/activate -s)` will setup host's environment variables within GitHub CI. `NXDK_DIR` no longer work within Makefile file as it needs to be in environment variable in order for nxdk build system to work properly.