### PR TITLE
Add 3 relative thread stack tests

### DIFF
--- a/assertion_defines.h
+++ b/assertion_defines.h
@@ -23,4 +23,13 @@
         test_passed = 0; \
     }
 
+#define GEN_CHECK_RANGE(check_var, expected_var, size, varname) \
+    if(check_var < expected_var || check_var > expected_var + size) { \
+        print( \
+            "  Expected range %s = 0x%x-0x%x, Got %s = 0x%x", \
+            varname, expected_var, expected_var + size, varname, check_var \
+        ); \
+        test_passed = 0; \
+    }
+
 #endif // ASSERTION_DEFINES_H

--- a/assertion_defines.h
+++ b/assertion_defines.h
@@ -32,4 +32,15 @@
         test_passed = 0; \
     }
 
+#define GEN_CHECK_ARRAY(check_var, expected_var, size, varname) \
+    for (unsigned i = 0; i < size; i++) { \
+        if (check_var[i] != expected_var[i]) { \
+            print(\
+            "  Expected array %s[%u] = 0x%x, Got %s[%u] = 0x%x", \
+                varname, i, expected_var[i], varname, i, check_var[i] \
+            ); \
+                test_passed = 0; \
+        } \
+    }
+
 #endif // ASSERTION_DEFINES_H

--- a/rtl_tests.c
+++ b/rtl_tests.c
@@ -990,8 +990,28 @@ void test_RtlFreeUnicodeString(){
     print_test_footer(func_num, func_name, tests_passed);
 }
 
+void stub_RtlGetCallersAddress(PVOID* CallerAddress_test, PVOID* CallersCaller_test, PULONG CallerAddress_expected){
+    *CallerAddress_expected = (ULONG)__builtin_return_address(0);
+    RtlGetCallersAddress(CallerAddress_test, CallersCaller_test);
+}
+
 void test_RtlGetCallersAddress(){
-    /* FIXME: This is a stub! implement this function! */
+    const char* func_num = "0x0120";
+    const char* func_name = "RtlGetCallersAddress";
+    BOOL test_passed = 1;
+
+    print_test_header(func_num, func_name);
+
+    ULONG CallerAddress_test, CallersCaller_test, CallerAddress_expected;
+    ULONG CallersCaller_expected = (ULONG)__builtin_return_address(0);
+
+    stub_RtlGetCallersAddress((PVOID*)&CallerAddress_test, (PVOID*)&CallersCaller_test, &CallerAddress_expected);
+
+    GEN_CHECK(CallerAddress_test, CallerAddress_expected, "CallerAddress");
+
+    GEN_CHECK(CallersCaller_test, CallersCaller_expected, "CallersCaller");
+
+    print_test_footer(func_num, func_name, test_passed);
 }
 
 void test_RtlInitAnsiString(){


### PR DESCRIPTION
Three tests added:
 - RtlWalkFrameChain
 - RtlCaptureStackBackTrace
 - RtlGetCallersAddress
 
Both hardware and cxbxr (local) are passing tests.
**NOTE: cxbxr upstream will not pass the test due to incorrect implement which is currently awaiting for https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/pull/2339 merge and additional pull request.**

---

Hardware test:
```
Kernel Test Suite
Random seed used is 0
Config File Was Loaded. Only running requested tests.
-----------------------------------------------------
0x010A - RtlCaptureStackBackTrace: Tests Starting
0x010A - RtlCaptureStackBackTrace: All tests PASSED
0x0120 - RtlGetCallersAddress: Tests Starting
0x0120 - RtlGetCallersAddress: All tests PASSED
0x013F - RtlWalkFrameChain: Tests Starting
  INFO: callers[4] = 0x00016cba
  INFO: callers[5] = 0x0001b5cb
  INFO: callers[6] = 0x0001b4cd
  INFO: callers[7] = 0x00039ed0
  INFO: callers[8] = 0x0003a299
  INFO: callers[9] = 0x00035240
0x013F - RtlWalkFrameChain: All tests PASSED
```