### PR TITLE
add ObReferenceObjectByHandle test

### DIFF
--- a/ob_tests.c
+++ b/ob_tests.c
@@ -1,3 +1,8 @@
+#include <xboxkrnl/xboxkrnl.h>
+#include "output.h"
+#include "assertion_defines.h"
+#include "common_assertions.h"
+
 void test_ObCreateObject(){
     /* FIXME: This is a stub! implement this function! */
 }
@@ -23,7 +28,52 @@ void test_ObOpenObjectByPointer(){
 }
 
 void test_ObReferenceObjectByHandle(){
-    /* FIXME: This is a stub! implement this function! */
+    const char* func_num = "0x00F6";
+    const char* func_name = "ObReferenceObjectByHandle";
+    BOOL test_passed = 1;
+    PVOID object_return;
+    NTSTATUS result;
+
+    print_test_header(func_num, func_name);
+
+    typedef struct {
+        const char* message;
+        HANDLE handle;
+        POBJECT_TYPE object_type;
+        NTSTATUS expected_result;
+        PVOID expected_object_return;
+    } reference_object_array;
+
+    reference_object_array reference_object_handle_test[] = {
+        // test with invalid handle with null object type
+        { "unknown (invalid / NULL)", (HANDLE)100000, NULL, STATUS_INVALID_HANDLE, NULL },
+        // test with invalid handle with null object type
+        { "unknown (invalid / invalid)", (HANDLE)100000, (POBJECT_TYPE)&func_name, STATUS_INVALID_HANDLE, NULL },
+        // test with invalid handle with thread object type
+        { "thread (invalid / PsThreadObjectType)", (HANDLE)100000, &PsThreadObjectType, STATUS_INVALID_HANDLE, NULL },
+        // test with invalid special handle (NtCurrentProcess) with null object type
+        { "thread (-1 aka NtCurrentProcess / NULL)", (HANDLE)-1, NULL, STATUS_INVALID_HANDLE, NULL },
+        // test with invalid special handle (NtCurrentProcess) with thread object type
+        { "thread (-1 aka NtCurrentProcess / PsThreadObjectType)", (HANDLE)-1, &PsThreadObjectType, STATUS_INVALID_HANDLE, NULL },
+        // test with valid special handle (NtCurrentThread) with null object type
+        { "thread (-2 aka NtCurrentThread / NULL)", (HANDLE)-2, NULL, STATUS_SUCCESS, (PVOID)KeGetCurrentThread() },
+        // test with valid special handle (NtCurrentThread) with thread object type
+        { "thread (-2 aka NtCurrentThread / PsThreadObjectType)", (HANDLE)-2, &PsThreadObjectType, STATUS_SUCCESS, (PVOID)KeGetCurrentThread() },
+        // test with valid special handle (NtCurrentThread) with symbolic link object type
+        { "thread (-2 aka NtCurrentThread / ObSymbolicLinkObjectType)", (HANDLE)-2, &ObSymbolicLinkObjectType, STATUS_OBJECT_TYPE_MISMATCH, NULL },
+    };
+    size_t reference_object_handle_test_size = sizeof(reference_object_handle_test) / sizeof(reference_object_handle_test[0]);
+
+    for (unsigned i = 0; i < reference_object_handle_test_size; i++) {
+        result = ObReferenceObjectByHandle(reference_object_handle_test[i].handle, reference_object_handle_test[i].object_type, &object_return);
+        if (result == STATUS_SUCCESS) {
+            NtClose(reference_object_handle_test[i].handle);
+        }
+        test_passed &= assert_NTSTATUS(result, reference_object_handle_test[i].expected_result, func_name);
+        GEN_CHECK(object_return, reference_object_handle_test[i].expected_object_return, reference_object_handle_test[i].message);
+    }
+
+    print_test_footer(func_num, func_name, test_passed);
 }
 
 void test_ObReferenceObjectByName(){


### PR DESCRIPTION
hardware test:
```
0x00F6 - ObReferenceObjectByHandle: Tests Starting
  Function 'ObReferenceObjectByHandle' returned 0xc0000008 as expected
  Function 'ObReferenceObjectByHandle' returned 0xc0000008 as expected
  Function 'ObReferenceObjectByHandle' returned 0xc0000008 as expected
  Function 'ObReferenceObjectByHandle' returned 0xc0000008 as expected
  Function 'ObReferenceObjectByHandle' returned 0xc0000008 as expected
  Function 'ObReferenceObjectByHandle' returned 0x0 as expected
  Function 'ObReferenceObjectByHandle' returned 0x0 as expected
  Function 'ObReferenceObjectByHandle' returned 0xc0000024 as expected
0x00F6 - ObReferenceObjectByHandle: All tests PASSED
```

UPDATE:
I'm unable to test with any cxbxr's builds due to fatal crash, even with last published released build of xbox kernel test suite also crash. I can confirm the issue came from my OS for some reason at the moment.

However, cxbxr's error on test result will be resolve by a fix from https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/pull/2414 pull request.