### PR TITLE
exclude compiled bin folder from git history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@
 *.idb
 *.pdb
 
+# Compiled binary folder
+bin/
+
 # Kernel Module Compile Results
 *.mod*
 *.cmd


### PR DESCRIPTION
Exclude compiled bin folder from git history, it was missed while compiling project somehow.