### PR TITLE
Add support for devcontainer locally and remotely

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM ghcr.io/xboxdev/nxdk:latest
+
+# NOTE: curl-dev is require to workaround unknown option failure from libcurl (assumed is old version)
+RUN apk add build-base ninja zip unzip curl-dev curl git
+
+# Initial env variable for vcpkg path
+ENV VCPKG_ROOT="/usr/local/vcpkg"
+ENV PATH="${PATH}:${VCPKG_ROOT}"
+
+# Install vcpkg
+RUN git clone https://github.com/microsoft/vcpkg ${VCPKG_ROOT} \
+    && ${VCPKG_ROOT}/bootstrap-vcpkg.sh
+
+# Include missing path to nxdk's bin directory.
+ENV PATH="${NXDK_DIR}/bin:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+	"name": "Xbox Development",
+
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cpptools-extension-pack",
+				"ms-vscode.makefile-tools"
+			]
+		}
+	}
+}

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,22 @@
+{
+    "configurations": [
+        {
+            "name": "nxdk",
+            "includePath": [
+                "${default}",
+                "${NXDK_DIR}/lib",
+                "${NXDK_DIR}/lib/pdclib/include",
+                "${NXDK_DIR}/lib/pdclib/platform/xbox/include",
+                "${NXDK_DIR}/lib/winapi",
+                "${NXDK_DIR}/lib/xboxrt/libc_extensions",
+                "${NXDK_DIR}/lib/xboxrt/vcruntime"
+            ],
+            "compilerArgs": [
+                "-fms-extensions"
+            ],
+            "compilerPath": "${NXDK_DIR}/bin/nxdk-cc",
+            "intelliSenseMode": "windows-clang-x86"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "C_Cpp.autoAddFileAssociations": false,
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}/src"
+    ],
+    "files.exclude": {
+        "**/*.d": true,
+        "**/*.obj": true
+    }
+}


### PR DESCRIPTION
I had not thoroughly tested this template for visual studio code. There could be some unnecessary extension, intellisense issues, etc.

However, this template had been my goto devcontainer for other nxdk relative projects. Feel free to find any faults and note them here. And feel free to create codespace, from GitHub, to try them out from the web browser. Please remember to delete your codespace creation after being done with it.