### PR TITLE
Misc Minor Fixes

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -89,6 +89,7 @@ static void run_tests()
             kernel_thunk_table[vector_get(&tests_to_run, k)]();
         }
     }
+    print("------------------------ End of Tests -----------------------");
 }
 
 void main(void){

--- a/src/tests/av/AvGetSavedDataAddress.c
+++ b/src/tests/av/AvGetSavedDataAddress.c
@@ -1,18 +1,22 @@
 #include <xboxkrnl/xboxkrnl.h>
 
 #include "util/output.h"
+#include "assertions/defines.h"
 
 void test_AvGetSavedDataAddress()
 {
     // FIXME this test is broken - We shouldn't pass NULL to AvSetSavedDataAddress. This is just an hack to avoid a system crash.
     const char* func_num = "0x0001";
     const char* func_name = "AvGetSavedDataAddress";
-    BOOL tests_passed = 1;
+    BOOL test_passed = 1;
     print_test_header(func_num, func_name);
 
-    AvSetSavedDataAddress(NULL);
-    tests_passed = AvGetSavedDataAddress() == NULL ? 1 : 0;
-    print("AvGetSavedDataAddress()=0x%x", AvGetSavedDataAddress());
+    PVOID address_old = AvGetSavedDataAddress();
 
-    print_test_footer(func_num, func_name, tests_passed);
+    AvSetSavedDataAddress(NULL);
+    GEN_CHECK(AvGetSavedDataAddress() == NULL, TRUE, "SavedDataAddress");
+
+    AvSetSavedDataAddress(address_old);
+
+    print_test_footer(func_num, func_name, test_passed);
 }

--- a/src/tests/av/AvSendTVEncoderOption.c
+++ b/src/tests/av/AvSendTVEncoderOption.c
@@ -1,6 +1,6 @@
 #include <xboxkrnl/xboxkrnl.h>
 
-#include "global.h"
+#include "global.h" // for NV2A_MMIO_BASE var
 #include "util/output.h"
 
 void test_AvSendTVEncoderOption()

--- a/src/tests/av/AvSendTVEncoderOption.c
+++ b/src/tests/av/AvSendTVEncoderOption.c
@@ -14,7 +14,7 @@ void test_AvSendTVEncoderOption()
 
     unsigned long res = 0;
     AvSendTVEncoderOption((void *)NV2A_MMIO_BASE, 6, 0, &res);
-    print("AvSendTVEncoderOption: %d (0=AV_PACK_NONE 1=AV_PACK_STANDARD 2=AV_PACK_RFU 3=AV_PACK_SCART 4=AV_PACK_HDTV 5=AV_PACK_VGA 6=AV_PACK_SVIDEO)", (int)res);
+    print("AvSendTVEncoderOption: %lu (0=AV_PACK_NONE 1=AV_PACK_STANDARD 2=AV_PACK_RFU 3=AV_PACK_SCART 4=AV_PACK_HDTV 5=AV_PACK_VGA 6=AV_PACK_SVIDEO)", res);
 
     print_test_footer(func_num, func_name, tests_passed);
 }

--- a/src/tests/io/IoCreateSymbolicLink.c
+++ b/src/tests/io/IoCreateSymbolicLink.c
@@ -1,6 +1,6 @@
 #include <xboxkrnl/xboxkrnl.h>
 #include <windows.h>
-#include <stdint.h>
+#include <stddef.h>
 
 #include "util/output.h"
 #include "assertions/common.h"

--- a/src/tests/ob/ObReferenceObjectByHandle.c
+++ b/src/tests/ob/ObReferenceObjectByHandle.c
@@ -1,4 +1,5 @@
 #include <xboxkrnl/xboxkrnl.h>
+#include <stddef.h>
 
 #include "util/output.h"
 #include "assertions/defines.h"

--- a/src/tests/rtl/RtlMoveMemory.c
+++ b/src/tests/rtl/RtlMoveMemory.c
@@ -1,7 +1,7 @@
 #include <xboxkrnl/xboxkrnl.h>
 #include <stdlib.h>
 
-#include "global.h"
+#include "global.h" // for seed var
 #include "util/output.h"
 
 void test_RtlMoveMemory()

--- a/src/tests/rtl/suite/string_append.c
+++ b/src/tests/rtl/suite/string_append.c
@@ -125,7 +125,7 @@ void test_RtlAppendUnicodeToString()
     BOOL tests_passed = 1;
     print_test_header(func_num, func_name);
 
-    const WCHAR src_text[] = L"Xbox";
+    const WCHAR* src_text = L"Xbox";
     const uint8_t num_chars_in_src = wcslen(src_text) + 1;
     WCHAR buffer[num_chars_in_src * 2];
     WCHAR expected_result[num_chars_in_src * 2];

--- a/src/tests/rtl/suite/string_uppercase.c
+++ b/src/tests/rtl/suite/string_uppercase.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <ctype.h>
 
-#include "global.h"
+#include "global.h" // for seed var
 #include "util/output.h"
 #include "assertions/defines.h"
 

--- a/src/util/output.c
+++ b/src/util/output.c
@@ -19,7 +19,7 @@ void print(char* str, ...)
     vsnprintf (buffer, 499, str, args);
     va_end(args);
     /**** PRINT ON TV (REAL HW) ****/
-    debugPrint(buffer);
+    debugPrint("%s", buffer);
     debugPrint("\n");
     /*******************************/
 
@@ -89,7 +89,7 @@ int write_to_output_file(
         debugPrint("ERROR: Could not write to output file");
     }
     if(bytes_written != num_bytes_to_print) {
-        debugPrint("ERROR: Bytes written = %u, bytes expected to write = %u",
+        debugPrint("ERROR: Bytes written = %lu, bytes expected to write = %lu",
                    bytes_written, num_bytes_to_print);
         ret = 1;
     }


### PR DESCRIPTION
The following fixes are:
- print "end of tests" to ensure there is no issue with any tests performed. (such as deadlock, crash, etc)
- On compilation, there are several warnings reported. Now there are no warnings reported.
- Update AvGetSavedDataAddress test to save and restore previous value. Plus replace custom message to GEN_CHECK macro.
- Fix red underline from Visual Studio Code's editor view for not using proper includes.
- Clarify what is used from global header file.