### PR TITLE
Add GEN_CHECK_ARRAY_MEMBER and ARRAY_SIZE Macro Features

### DIFF
--- a/src/assertions/defines.h
+++ b/src/assertions/defines.h
@@ -41,3 +41,14 @@
             test_passed = 0; \
         } \
     }
+
+#define GEN_CHECK_ARRAY_MEMBER(var, m_check, m_expected, size, varname) \
+    for (unsigned i = 0; i < size; i++) { \
+        if (var[i].m_check != var[i].m_expected) { \
+            print( \
+                "  Expected array %s[%u].%s = 0x%x, Got %s[%u].%s = 0x%x", \
+                varname, i, #m_expected, var[i].m_expected, varname, i, #m_check, var[i].m_check \
+            ); \
+            test_passed = 0; \
+        } \
+    }

--- a/src/assertions/defines.h
+++ b/src/assertions/defines.h
@@ -35,9 +35,9 @@
     for (unsigned i = 0; i < size; i++) { \
         if (check_var[i] != expected_var[i]) { \
             print(\
-            "  Expected array %s[%u] = 0x%x, Got %s[%u] = 0x%x", \
+                "  Expected array %s[%u] = 0x%x, Got %s[%u] = 0x%x", \
                 varname, i, expected_var[i], varname, i, check_var[i] \
             ); \
-                test_passed = 0; \
+            test_passed = 0; \
         } \
     }

--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,7 @@
 #include <windows.h>
 
 #include "util/output.h"
+#include "util/misc.h"
 #include "util/vector.h"
 #include "util/string_extra.h"
 #include "global.h"
@@ -77,7 +78,7 @@ static void run_tests()
     if(tests_to_run.size == 0) {
         print("No Specific tests specified. Running all tests (Single Pass).");
         print("-------------------------------------------------------------");
-        int table_size = sizeof(kernel_thunk_table) / sizeof(*kernel_thunk_table);
+        int table_size = ARRAY_SIZE(kernel_thunk_table);
         for(int k=0;k<table_size;k++){
             kernel_thunk_table[k]();
         }

--- a/src/tests/io/IoCreateSymbolicLink.c
+++ b/src/tests/io/IoCreateSymbolicLink.c
@@ -3,6 +3,7 @@
 #include <stddef.h>
 
 #include "util/output.h"
+#include "util/misc.h"
 #include "assertions/common.h"
 
 /* possible missing
@@ -61,7 +62,7 @@ void test_IoCreateSymbolicLink()
         { &device_str, STATUS_OBJECT_PATH_NOT_FOUND },
         { &device_bad_path_nonexistent_str, STATUS_OBJECT_PATH_NOT_FOUND },
     };
-    size_t symlink_test_size = sizeof(symlink_test_str)/sizeof(symlink_test_str[0]);
+    size_t symlink_test_size = ARRAY_SIZE(symlink_test_str);
 
     str_array device_test_str[] = {
         { &null_str, STATUS_INVALID_PARAMETER },
@@ -73,7 +74,7 @@ void test_IoCreateSymbolicLink()
         { &symlink_str, STATUS_INVALID_PARAMETER },
         { &symlink_no_slash_str, STATUS_INVALID_PARAMETER },
     };
-    size_t device_test_str_size = sizeof(device_test_str)/sizeof(device_test_str[0]);
+    size_t device_test_str_size = ARRAY_SIZE(device_test_str);
 
     print("  Running tests for symbolic link inputs");
     for (unsigned i = 0; i < symlink_test_size; i++) {

--- a/src/tests/ob/ObReferenceObjectByHandle.c
+++ b/src/tests/ob/ObReferenceObjectByHandle.c
@@ -2,6 +2,7 @@
 #include <stddef.h>
 
 #include "util/output.h"
+#include "util/misc.h"
 #include "assertions/defines.h"
 #include "assertions/common.h"
 
@@ -41,7 +42,7 @@ void test_ObReferenceObjectByHandle()
         // test with valid special handle (NtCurrentThread) with symbolic link object type
         { "thread (-2 aka NtCurrentThread / ObSymbolicLinkObjectType)", (HANDLE)-2, &ObSymbolicLinkObjectType, STATUS_OBJECT_TYPE_MISMATCH, NULL },
     };
-    size_t reference_object_handle_test_size = sizeof(reference_object_handle_test) / sizeof(reference_object_handle_test[0]);
+    size_t reference_object_handle_test_size = ARRAY_SIZE(reference_object_handle_test);
 
     for (unsigned i = 0; i < reference_object_handle_test_size; i++) {
         result = ObReferenceObjectByHandle(reference_object_handle_test[i].handle, reference_object_handle_test[i].object_type, &object_return);

--- a/src/tests/rtl/RtlCaptureContext.c
+++ b/src/tests/rtl/RtlCaptureContext.c
@@ -3,6 +3,7 @@
 
 #include "global.h" // for (passed|failed)_test vars
 #include "util/output.h"
+#include "util/misc.h"
 
 // Notes about this function: The official kernel allocates 0x440 bytes for the CONTEXT structure.
 // That does not match with any other implementation of CONTEXT that I have been able to find.
@@ -77,7 +78,7 @@ void test_RtlCaptureContext()
                                &result_context.SegCs, &result_context.SegSs, &result_context.EFlags};
     const char* reg_names[] = {"Eax", "Ebx", "Ecx", "Edx", "Esi", "Edi", "SegCs", "SegSs", "EFlags"};
 
-    for(uint8_t i = 0; i < sizeof(expected_vals) / sizeof(DWORD*); i++) {
+    for(uint8_t i = 0; i < ARRAY_SIZE(expected_vals); i++) {
         const char* result_text = passed_text;
         if(*result_vals[i] != *expected_vals[i]) {
             tests_passed = 0;

--- a/src/tests/rtl/RtlExtendedIntegerMultiply.c
+++ b/src/tests/rtl/RtlExtendedIntegerMultiply.c
@@ -3,6 +3,7 @@
 
 #include "global.h" // for (passed|failed)_test vars
 #include "util/output.h"
+#include "util/misc.h"
 
 void test_RtlExtendedIntegerMultiply()
 {
@@ -16,7 +17,7 @@ void test_RtlExtendedIntegerMultiply()
     const LONGLONG expected_results[] = {0,  0, 225, -225, 225};
     LARGE_INTEGER multiplicand, result;
 
-    for(uint8_t i = 0; i < sizeof(expected_results) / sizeof(LONGLONG); i++) {
+    for(uint8_t i = 0; i < ARRAY_SIZE(expected_results); i++) {
         const char* result_text = passed_text;
         multiplicand.QuadPart = multiplicands[i];
         result = RtlExtendedIntegerMultiply(multiplicand, multipliers[i]);

--- a/src/tests/rtl/RtlExtendedLargeIntegerDivide.c
+++ b/src/tests/rtl/RtlExtendedLargeIntegerDivide.c
@@ -3,6 +3,7 @@
 
 #include "global.h" // for (passed|failed)_test vars
 #include "util/output.h"
+#include "util/misc.h"
 
 // A few things to note about this function:
 // 1. Passing NULL into the remainder field is legal.
@@ -24,7 +25,7 @@ void test_RtlExtendedLargeIntegerDivide()
     LARGE_INTEGER dividend, result, e_result;
     ULONG remainder;
 
-    for(uint8_t i = 0; i < sizeof(expected_results) / sizeof(LONGLONG); i++) {
+    for(uint8_t i = 0; i < ARRAY_SIZE(expected_results); i++) {
         const char* result_text = passed_text;
         dividend.QuadPart = dividends[i];
         e_result.QuadPart = expected_results[i];

--- a/src/tests/rtl/RtlFillMemory.c
+++ b/src/tests/rtl/RtlFillMemory.c
@@ -3,6 +3,7 @@
 
 #include "global.h" // for (passed|failed)_test vars
 #include "util/output.h"
+#include "util/misc.h"
 
 void test_RtlFillMemory()
 {
@@ -18,7 +19,7 @@ void test_RtlFillMemory()
     BOOL individual_test_passes = 1;
 
     RtlZeroMemory(buffer, buf_len);
-    for(uint8_t i = 0; i < sizeof(lengths) / sizeof(DWORD); i++) {
+    for(uint8_t i = 0; i < ARRAY_SIZE(lengths); i++) {
         const char* result_text = passed_text;
         RtlFillMemory(buffer, lengths[i], fills[i]);
         for(uint8_t y = 0; y < buf_len; y++) {

--- a/src/tests/rtl/RtlFillMemoryUlong.c
+++ b/src/tests/rtl/RtlFillMemoryUlong.c
@@ -3,6 +3,7 @@
 
 #include "global.h" // for (passed|failed)_test vars
 #include "util/output.h"
+#include "util/misc.h"
 
 void test_RtlFillMemoryUlong()
 {
@@ -18,7 +19,7 @@ void test_RtlFillMemoryUlong()
     BOOL individual_test_passes = 1;
 
     RtlZeroMemory(buffer, buf_len * sizeof(ULONG));
-    for(uint8_t i = 0; i < sizeof(lengths) / sizeof(SIZE_T); i++) {
+    for(uint8_t i = 0; i < ARRAY_SIZE(lengths); i++) {
         const char* result_text = passed_text;
         RtlFillMemoryUlong(buffer, lengths[i] * sizeof(ULONG), patterns[i]);
         for(uint8_t y = 0; y < buf_len; y++) {

--- a/src/tests/rtl/RtlUlongByteSwap.c
+++ b/src/tests/rtl/RtlUlongByteSwap.c
@@ -3,6 +3,7 @@
 
 #include "global.h" // for (passed|failed)_test vars
 #include "util/output.h"
+#include "util/misc.h"
 
 void test_RtlUlongByteSwap()
 {
@@ -15,7 +16,7 @@ void test_RtlUlongByteSwap()
     const ULONG expected_results[] = {0x00FF00FF, 0x78563412, 0xA1B2C3D4};
     ULONG result;
 
-    for(uint8_t i = 0; i < sizeof(inputs) / sizeof(ULONG); i++) {
+    for(uint8_t i = 0; i < ARRAY_SIZE(inputs); i++) {
         const char* result_text = passed_text;
         result = RtlUlongByteSwap(inputs[i]);
         if(result != expected_results[i]) {

--- a/src/tests/rtl/RtlUshortByteSwap.c
+++ b/src/tests/rtl/RtlUshortByteSwap.c
@@ -3,6 +3,7 @@
 
 #include "global.h" // for (passed|failed)_test vars
 #include "util/output.h"
+#include "util/misc.h"
 
 void test_RtlUshortByteSwap()
 {
@@ -15,7 +16,7 @@ void test_RtlUshortByteSwap()
     const USHORT expected_results[] = {0x00FF, 0xFF00, 0x3412, 0xE0F0};
     USHORT result;
 
-    for(uint8_t i = 0; i < sizeof(inputs) / sizeof(USHORT); i++) {
+    for(uint8_t i = 0; i < ARRAY_SIZE(inputs); i++) {
         const char* result_text = passed_text;
         result = RtlUshortByteSwap(inputs[i]);
         if(result != expected_results[i]) {

--- a/src/tests/rtl/suite/comparison.c
+++ b/src/tests/rtl/suite/comparison.c
@@ -3,6 +3,7 @@
 
 #include "global.h" // for (passed|failed)_test vars
 #include "util/output.h"
+#include "util/misc.h"
 #include "assertions/rtl.h"
 
 void test_RtlCompareMemory()
@@ -170,7 +171,7 @@ void test_RtlEqualString()
     BOOLEAN      expected_result[]  = {1    , 1    , 0    , 1    , 0    , 0    };
 
     BOOLEAN result;
-    for(uint8_t i = 0; i < sizeof(str1_inputs) / sizeof(ANSI_STRING*); i++) {
+    for(uint8_t i = 0; i < ARRAY_SIZE(str1_inputs); i++) {
         const char* result_text = passed_text;
         result = RtlEqualString(str1_inputs[i], str2_inputs[i], case_insensitive[i]);
         if(result != expected_result[i]) {

--- a/src/tests/rtl/suite/string_conversion.c
+++ b/src/tests/rtl/suite/string_conversion.c
@@ -5,6 +5,7 @@
 #include <wchar.h>
 
 #include "util/output.h"
+#include "util/misc.h"
 #include "assertions/common.h"
 #include "assertions/rtl.h"
 
@@ -86,7 +87,7 @@ void test_RtlCharToInteger()
     NTSTATUS base_ret, neg_base_ret, format_ret, neg_format_ret;
     ULONG    base_result, neg_base_result, format_result, neg_format_result, neg_expected_result;
     CHAR     neg_base_buffer[50], format_buffer[50], neg_format_buffer[50];
-    for(uint8_t i = 0; i < sizeof(expected_results) / sizeof(ULONG); i++) {
+    for(uint8_t i = 0; i < ARRAY_SIZE(expected_results); i++) {
         strcpy(neg_base_buffer, "-");
         strcat(neg_base_buffer, inputs[i]);
 
@@ -228,8 +229,8 @@ void test_RtlUnicodeStringToAnsiString()
     tests_passed &= assert_NTSTATUS(result, STATUS_SUCCESS, func_name);
     tests_passed &= assert_ansi_string(
         &ansi_string,
-        sizeof(unicode_text) / sizeof(WCHAR) - 1,
-        sizeof(unicode_text) / sizeof(WCHAR),
+        ARRAY_SIZE(unicode_text) - 1,
+        ARRAY_SIZE(unicode_text),
         ansi_text,
         "Convert full unicode to ansi string."
     );
@@ -254,7 +255,7 @@ void test_RtlUnicodeStringToAnsiString()
     tests_passed &= assert_NTSTATUS(result, STATUS_SUCCESS, func_name);
     tests_passed &= assert_ansi_string(
         &ansi_string,
-        sizeof(unicode_text) / sizeof(WCHAR) - 1,
+        ARRAY_SIZE(unicode_text) - 1,
         UINT16_MAX,
         ansi_text_max,
         "Unicode to max ansi string."

--- a/src/tests/rtl/suite/string_lowercase.c
+++ b/src/tests/rtl/suite/string_lowercase.c
@@ -3,6 +3,7 @@
 
 #include "global.h" // for (passed|failed)_test vars
 #include "util/output.h"
+#include "util/misc.h"
 
 void test_RtlDowncaseUnicodeChar()
 {
@@ -15,7 +16,7 @@ void test_RtlDowncaseUnicodeChar()
     WCHAR input[]           = {L' ', L'w', L'W', L'X', L']', L'$'};
     WCHAR expected_output[] = {L' ', L'w', L'w', L'x', L']', L'$'};
 
-    for(uint8_t i = 0; i < sizeof(input) / sizeof(WCHAR); i++) {
+    for(uint8_t i = 0; i < ARRAY_SIZE(input); i++) {
         const char* result_text = passed_text;
         result = RtlDowncaseUnicodeChar(input[i]);
         if(result != expected_output[i]) {

--- a/src/util/misc.h
+++ b/src/util/misc.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+#endif


### PR DESCRIPTION
```c
typedef struct _test_struct {
    uint8_t expected_result;
    uint8_t result;
} test_struct;

test_struct tests[]{
    { .expected_result = 1, .result = 1 },
    { .expected_result = 2, .result = 5 },
    { .expected_result = 3, .result = 6 },
    { .expected_result = 4, .result = 7 }
};

GEN_CHECK_ARRAY_MEMBER(tests, result, expected_result, ARRAY_SIZE(tests), "tests");
```

As for GEN_CHECK_ARRAY_MEMBER test, using example above will output:
>  Expected array tests[1].expected_result = 0x2, Got tests[1].result = 0x5
>  Expected array tests[2].expected_result = 0x3, Got tests[2].result = 0x6
>  Expected array tests[3].expected_result = 0x4, Got tests[3].result = 0x7

With these additions, it will make future codes easier to write.
---

**EDIT:** Tested on hardware and all are passing. Plus confirmed with preexisting verbose passed tests such as RtlEqualString test. Beside, ARRAY_SIZE macro shouldn't harm and is well used common macro.