### PR TITLE
Fix RtlAnsiStringToUnicodeString Test's Variables Uninitialized

### DIFF
--- a/src/tests/rtl/suite/string_conversion.c
+++ b/src/tests/rtl/suite/string_conversion.c
@@ -18,8 +18,8 @@ void test_RtlAnsiStringToUnicodeString()
     print_test_header(func_num, func_name);
 
     const uint32_t long_str_size = 0x10000;
-    UNICODE_STRING dest_str;
-    ANSI_STRING src_str;
+    UNICODE_STRING dest_str = { 0 };
+    ANSI_STRING src_str = { 0 };
     CHAR* long_str = malloc(sizeof(CHAR) * long_str_size);
     if(long_str == NULL) {
         print("ERROR: Could not malloc long_str");


### PR DESCRIPTION
Resolve issue for #57 ticket and I recently encountered same issue in Cxbx-Reloaded.

close #57