### PR TITLE
Improve Log Output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 XBE_TITLE=kernel\ test\ suite
 recursivewildcard=$(foreach d,$(wildcard $(1:=/*)),$(call recursivewildcard,$d,$2) $(filter $(subst *,%,$2),$d))
 SRCS = $(call recursivewildcard,src,*.c)
-NXDK_CFLAGS = -I$(CURDIR)/src
+GIT_VERSION = "$(shell git describe --always --tags --first-parent --dirty)"
+NXDK_CFLAGS = -I$(CURDIR)/src -DGIT_VERSION=\"$(GIT_VERSION)\"
 include $(NXDK_DIR)/Makefile

--- a/src/assertions/common.c
+++ b/src/assertions/common.c
@@ -1,27 +1,22 @@
 #include "common.h"
 #include "defines.h"
 
-BOOL assert_NTSTATUS(
+BOOL assert_NTSTATUS_ex(
     NTSTATUS status,
     NTSTATUS expected_status,
-    const char* func_name)
+    const char* func_name,
+    int line_number)
 {
     ASSERT_HEADER
     if(status != expected_status) {
         print(
-            "  Expected return status of function '%s' = 0x%x, got = 0x%x",
+            "  ERROR(line %d): Expected return status of function '%s' = 0x%x, got = 0x%x",
+            line_number,
             func_name,
             expected_status,
             status
         );
         test_passed = 0;
-    }
-    else {
-        print(
-            "  Function '%s' returned 0x%x as expected",
-            func_name,
-            status
-        );
     }
     return test_passed;
 }

--- a/src/assertions/common.h
+++ b/src/assertions/common.h
@@ -2,8 +2,20 @@
 
 #include <xboxkrnl/xboxkrnl.h>
 
-BOOL assert_NTSTATUS(
+BOOL assert_NTSTATUS_ex(
     NTSTATUS,
     NTSTATUS,
-    const char*
+    const char*,
+    int
 );
+#define assert_NTSTATUS( \
+    status, \
+    expected_status, \
+    func_name \
+) \
+assert_NTSTATUS_ex( \
+    status, \
+    expected_status, \
+    func_name, \
+    __LINE__ \
+)

--- a/src/assertions/defines.h
+++ b/src/assertions/defines.h
@@ -5,50 +5,51 @@
 #define ASSERT_HEADER BOOL test_passed = 1;
 
 #define ASSERT_FOOTER(test_name) \
-    if(test_passed) { \
-        print("  Test '%s' PASSED", test_name); \
-    } \
-    else { \
+    if(!test_passed) { \
         print("  Test '%s' FAILED", test_name); \
     } \
     return test_passed;
 
-#define GEN_CHECK(check_var, expected_var, varname) \
+#define GEN_CHECK_EX(check_var, expected_var, varname, func_line) \
     if(check_var != expected_var) { \
         print( \
-            "  Expected %s = 0x%x, Got %s = 0x%x", \
-            varname, expected_var, varname, check_var \
+            "  ERROR(line %d): Expected %s = 0x%x, Got = 0x%x", \
+             func_line, varname, expected_var, check_var \
         ); \
         test_passed = 0; \
     }
+#define GEN_CHECK(check_var, expected_var, varname) GEN_CHECK_EX(check_var, expected_var, varname, __LINE__)
 
-#define GEN_CHECK_RANGE(check_var, expected_var, size, varname) \
+#define GEN_CHECK_RANGE_EX(check_var, expected_var, size, varname, func_line) \
     if(check_var < expected_var || check_var > expected_var + size) { \
         print( \
-            "  Expected range %s = 0x%x-0x%x, Got %s = 0x%x", \
-            varname, expected_var, expected_var + size, varname, check_var \
+            "  ERROR(line %d): Expected range %s = 0x%x-0x%x, Got = 0x%x", \
+            func_line, varname, expected_var, expected_var + size, check_var \
         ); \
         test_passed = 0; \
     }
+#define GEN_CHECK_RANGE(check_var, expected_var, size, varname) GEN_CHECK_RANGE_EX(check_var, expected_var, size, varname, __LINE__)
 
-#define GEN_CHECK_ARRAY(check_var, expected_var, size, varname) \
+#define GEN_CHECK_ARRAY_EX(check_var, expected_var, size, varname, func_line) \
     for (unsigned i = 0; i < size; i++) { \
         if (check_var[i] != expected_var[i]) { \
-            print(\
-                "  Expected array %s[%u] = 0x%x, Got %s[%u] = 0x%x", \
-                varname, i, expected_var[i], varname, i, check_var[i] \
+            print( \
+                "  ERROR(line %d): Expected array %s[%u] = 0x%x, Got = 0x%x", \
+                func_line, varname, i, expected_var[i], check_var[i] \
             ); \
             test_passed = 0; \
         } \
     }
+#define GEN_CHECK_ARRAY(check_var, expected_var, size, varname) GEN_CHECK_ARRAY_EX(check_var, expected_var, size, varname, __LINE__)
 
-#define GEN_CHECK_ARRAY_MEMBER(var, m_check, m_expected, size, varname) \
+#define GEN_CHECK_ARRAY_MEMBER_EX(var, m_check, m_expected, size, varname, func_line) \
     for (unsigned i = 0; i < size; i++) { \
         if (var[i].m_check != var[i].m_expected) { \
             print( \
-                "  Expected array %s[%u].%s = 0x%x, Got %s[%u].%s = 0x%x", \
-                varname, i, #m_expected, var[i].m_expected, varname, i, #m_check, var[i].m_check \
+                "  ERROR(line %d): Expected array %s[%u].%s = 0x%x, Got %s[%u].%s = 0x%x", \
+                func_line, varname, i, #m_expected, var[i].m_expected, varname, i, #m_check, var[i].m_check \
             ); \
             test_passed = 0; \
         } \
     }
+#define GEN_CHECK_ARRAY_MEMBER(var, m_check, m_expected, size, varname) GEN_CHECK_ARRAY_MEMBER_EX(var, m_check, m_expected, size, varname, __LINE__)

--- a/src/assertions/ex.c
+++ b/src/assertions/ex.c
@@ -2,20 +2,21 @@
 
 #include "defines.h"
 
-BOOL assert_ERWLOCK_equals(
+BOOL assert_ERWLOCK_equals_ex(
     PERWLOCK ReadWriteLock,
     LONG expected_LockCount,
     ULONG expected_WritersWaitingCount,
     ULONG expected_ReadersWaitingCount,
     ULONG expected_ReadersEntryCount,
-    const char* test_name)
+    const char* test_name,
+    int line_number)
 {
     ASSERT_HEADER
 
-    GEN_CHECK(ReadWriteLock->LockCount, expected_LockCount, "LockCount")
-    GEN_CHECK(ReadWriteLock->WritersWaitingCount, expected_WritersWaitingCount, "WritersWaitingCount")
-    GEN_CHECK(ReadWriteLock->ReadersWaitingCount, expected_ReadersWaitingCount, "ReadersWaitingCount")
-    GEN_CHECK(ReadWriteLock->ReadersEntryCount, expected_ReadersEntryCount, "ReadersEntryCount")
+    GEN_CHECK_EX(ReadWriteLock->LockCount, expected_LockCount, "LockCount", line_number)
+    GEN_CHECK_EX(ReadWriteLock->WritersWaitingCount, expected_WritersWaitingCount, "WritersWaitingCount", line_number)
+    GEN_CHECK_EX(ReadWriteLock->ReadersWaitingCount, expected_ReadersWaitingCount, "ReadersWaitingCount", line_number)
+    GEN_CHECK_EX(ReadWriteLock->ReadersEntryCount, expected_ReadersEntryCount, "ReadersEntryCount", line_number)
 
     ASSERT_FOOTER(test_name)
 }

--- a/src/assertions/ex.h
+++ b/src/assertions/ex.h
@@ -2,11 +2,29 @@
 
 #include <xboxkrnl/xboxkrnl.h>
 
-BOOL assert_ERWLOCK_equals(
+BOOL assert_ERWLOCK_equals_ex(
     PERWLOCK,
     LONG,
     ULONG,
     ULONG,
     ULONG,
-    const char*
+    const char*,
+    int
 );
+#define assert_ERWLOCK_equals( \
+    ReadWriteLock, \
+    expected_LockCount, \
+    expected_WritersWaitingCount, \
+    expected_ReadersWaitingCount, \
+    expected_ReadersEntryCount, \
+    test_name \
+) \
+assert_ERWLOCK_equals_ex( \
+    ReadWriteLock, \
+    expected_LockCount, \
+    expected_WritersWaitingCount, \
+    expected_ReadersWaitingCount, \
+    expected_ReadersEntryCount, \
+    test_name, \
+    __LINE__ \
+)

--- a/src/assertions/ke.c
+++ b/src/assertions/ke.c
@@ -1,14 +1,15 @@
 #include "ke.h"
 #include "defines.h"
 
-BOOL assert_critical_region(
+BOOL assert_critical_region_ex(
     PKTHREAD thread,
     ULONG expected_Apc,
-    const char* test_name)
+    const char* test_name,
+    int line_number)
 {
     ASSERT_HEADER
 
-    GEN_CHECK(thread->KernelApcDisable, expected_Apc, "KernelApcDisable")
+    GEN_CHECK_EX(thread->KernelApcDisable, expected_Apc, "KernelApcDisable", line_number)
 
     ASSERT_FOOTER(test_name)
 }

--- a/src/assertions/ke.h
+++ b/src/assertions/ke.h
@@ -2,4 +2,15 @@
 
 #include <xboxkrnl/xboxkrnl.h>
 
-BOOL assert_critical_region(PKTHREAD, ULONG, const char*);
+BOOL assert_critical_region_ex(PKTHREAD, ULONG, const char*, int);
+#define assert_critical_region( \
+    thread, \
+    expected_Apc, \
+    test_name \
+) \
+assert_critical_region_ex( \
+    thread, \
+    expected_Apc, \
+    test_name, \
+    __LINE__ \
+)

--- a/src/assertions/rtl.c
+++ b/src/assertions/rtl.c
@@ -4,40 +4,42 @@
 #include "rtl.h"
 #include "defines.h"
 
-BOOL assert_critical_section_equals(
+BOOL assert_critical_section_equals_ex(
     PRTL_CRITICAL_SECTION crit_section,
     LONG expected_LockCount,
     LONG expected_RecursionCount,
     HANDLE expected_OwningThread,
-    const char* test_name)
+    const char* test_name,
+    int line_number)
 {
     ASSERT_HEADER
 
-    GEN_CHECK(crit_section->LockCount, expected_LockCount, "LockCount")
-    GEN_CHECK(crit_section->RecursionCount, expected_RecursionCount, "RecursionCount")
-    GEN_CHECK(crit_section->OwningThread, expected_OwningThread, "OwningThread")
+    GEN_CHECK_EX(crit_section->LockCount, expected_LockCount, "LockCount", line_number);
+    GEN_CHECK_EX(crit_section->RecursionCount, expected_RecursionCount, "RecursionCount", line_number);
+    GEN_CHECK_EX(crit_section->OwningThread, expected_OwningThread, "OwningThread", line_number);
 
     ASSERT_FOOTER(test_name)
 }
 
-BOOL assert_ansi_string(
+BOOL assert_ansi_string_ex(
     PANSI_STRING string,
     USHORT expected_Length,
     USHORT expected_MaximumLength,
     PCHAR expected_Buffer,
-    const char* test_name)
+    const char* test_name,
+    int line_number)
 {
     ASSERT_HEADER
 
-    GEN_CHECK(string->Length, expected_Length, "Length");
-    GEN_CHECK(string->MaximumLength, expected_MaximumLength, "MaximumLength");
+    GEN_CHECK_EX(string->Length, expected_Length, "Length", line_number);
+    GEN_CHECK_EX(string->MaximumLength, expected_MaximumLength, "MaximumLength", line_number);
 
     if(expected_Buffer == NULL) {
-        GEN_CHECK(string->Buffer, NULL, "Buffer is NULL");
+        GEN_CHECK_EX(string->Buffer, NULL, "Buffer is NULL", line_number);
     }
     else {
         int result = memcmp(string->Buffer, expected_Buffer, expected_Length);
-        GEN_CHECK(result, 0, "memcmp result of Buffer");
+        GEN_CHECK_EX(result, 0, "memcmp result of Buffer", line_number);
         if(result) {
             print("  Buffer = %s, expected_Buffer = %s", string->Buffer, expected_Buffer);
         }
@@ -46,37 +48,39 @@ BOOL assert_ansi_string(
     ASSERT_FOOTER(test_name)
 }
 
-static BOOL assert_unicode_string(
+BOOL assert_unicode_string_ex(
     PUNICODE_STRING string,
     USHORT expected_Length,
     USHORT expected_MaximumLength,
     PWSTR expected_Buffer,
-    const char* test_name)
+    const char* test_name,
+    int line_number)
 {
     ASSERT_HEADER
 
-    GEN_CHECK(string->Length, expected_Length, "Length");
-    GEN_CHECK(string->MaximumLength, expected_MaximumLength, "MaximumLength");
+    GEN_CHECK_EX(string->Length, expected_Length, "Length", line_number);
+    GEN_CHECK_EX(string->MaximumLength, expected_MaximumLength, "MaximumLength", line_number);
 
     if(expected_Buffer == NULL) {
-        GEN_CHECK(string->Buffer, NULL, "Buffer is null");
+        GEN_CHECK_EX(string->Buffer, NULL, "Buffer is null", line_number);
     }
     else {
         int result = memcmp(string->Buffer, expected_Buffer, expected_Length);
-        GEN_CHECK(result, 0, "memcmp result of Buffer");
+        GEN_CHECK_EX(result, 0, "memcmp result of Buffer", line_number);
     }
 
     ASSERT_FOOTER(test_name)
 }
 
-BOOL assert_rtl_compared_bytes(
+BOOL assert_rtl_compared_bytes_ex(
     SIZE_T num_matching_bytes,
     SIZE_T expected_matching_bytes,
-    const char* test_name)
+    const char* test_name,
+    int line_number)
 {
     ASSERT_HEADER
 
-    GEN_CHECK(num_matching_bytes, expected_matching_bytes, "num_matching_bytes");
+    GEN_CHECK_EX(num_matching_bytes, expected_matching_bytes, "num_matching_bytes", line_number);
 
     ASSERT_FOOTER(test_name)
 }

--- a/src/assertions/rtl.h
+++ b/src/assertions/rtl.h
@@ -2,28 +2,87 @@
 
 #include <xboxkrnl/xboxkrnl.h>
 
-BOOL assert_critical_section_equals(
+BOOL assert_critical_section_equals_ex(
     PRTL_CRITICAL_SECTION,
     LONG,
     LONG,
     HANDLE,
-    const char*
+    const char*,
+    int
 );
+#define assert_critical_section_equals( \
+    crit_section, \
+    expected_LockCount, \
+    expected_RecursionCount, \
+    expected_OwningThread, \
+    test_name \
+) \
+assert_critical_section_equals_ex( \
+    crit_section, \
+    expected_LockCount, \
+    expected_RecursionCount, \
+    expected_OwningThread, \
+    test_name, \
+    __LINE__ \
+)
 
-BOOL assert_ansi_string(
+BOOL assert_ansi_string_ex(
     PANSI_STRING,
     USHORT,
     USHORT,
     PCHAR,
-    const char*
+    const char*,
+    int
 );
+#define assert_ansi_string( \
+    string, \
+    expected_Length, \
+    expected_MaximumLength, \
+    expected_Buffer, \
+    test_name \
+) \
+assert_ansi_string_ex( \
+    string, \
+    expected_Length, \
+    expected_MaximumLength, \
+    expected_Buffer, \
+    test_name, \
+    __LINE__ \
+)
 
-BOOL assert_unicode_string(
+BOOL assert_unicode_string_ex(
     PUNICODE_STRING,
     USHORT,
     USHORT,
     PWSTR,
-    const char*
+    const char*,
+    int
 );
+#define assert_unicode_string( \
+    string, \
+    expected_Length, \
+    expected_MaximumLength, \
+    expected_Buffer, \
+    test_name \
+) \
+assert_unicode_string_ex( \
+    string, \
+    expected_Length, \
+    expected_MaximumLength, \
+    expected_Buffer, \
+    test_name, \
+    __LINE__ \
+)
 
-BOOL assert_rtl_compared_bytes(SIZE_T, SIZE_T, const char*);
+BOOL assert_rtl_compared_bytes_ex(SIZE_T, SIZE_T, const char*, int);
+#define assert_rtl_compared_bytes( \
+    num_matching_bytes, \
+    expected_matching_bytes, \
+    test_name \
+) \
+assert_rtl_compared_bytes_ex( \
+    num_matching_bytes, \
+    expected_matching_bytes, \
+    test_name, \
+    __LINE__ \
+)

--- a/src/assertions/xc.c
+++ b/src/assertions/xc.c
@@ -3,11 +3,12 @@
 
 #include "defines.h"
 
-BOOL assert_hashed_result(
+BOOL assert_hashed_result_ex(
     PUCHAR input,
     size_t len,
     PUCHAR expected_result,
-    const char *test_name)
+    const char *test_name,
+    int line_number)
 {
     ASSERT_HEADER
     unsigned char sha1_ctx[116] = {0};
@@ -17,7 +18,7 @@ BOOL assert_hashed_result(
     XcSHAUpdate(sha1_ctx, input, len);
     XcSHAFinal(sha1_ctx, digest);
 
-    GEN_CHECK_ARRAY(digest, expected_result, 20, test_name)
+    GEN_CHECK_ARRAY_EX(digest, expected_result, 20, test_name, line_number)
 
     return test_passed;
 }

--- a/src/assertions/xc.h
+++ b/src/assertions/xc.h
@@ -3,9 +3,23 @@
 #include <xboxkrnl/xboxkrnl.h>
 #include <stddef.h>
 
-BOOL assert_hashed_result(
+BOOL assert_hashed_result_ex(
     PUCHAR input,
     size_t len,
     PUCHAR expected_result,
-    const char *test_name
+    const char *test_name,
+    int line_number
 );
+#define assert_hashed_result( \
+    input, \
+    len, \
+    expected_result, \
+    test_name \
+) \
+assert_hashed_result_ex( \
+    input, \
+    len, \
+    expected_result, \
+    test_name, \
+    __LINE__ \
+)

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,10 @@
 #include "global.h"
 #include "include/func_table.h"
 
+#ifndef GIT_VERSION
+#define GIT_VERSION "unknown"
+#endif
+
 int load_conf_file(char *file_path)
 {
     print("Trying to open config file: %s", file_path);
@@ -112,6 +116,7 @@ void main(void){
     open_output_file("D:\\kernel_tests.log");
 
     print("Kernel Test Suite");
+    print("build: " GIT_VERSION);
     run_tests();
 
 

--- a/src/tests/io/IoCreateSymbolicLink.c
+++ b/src/tests/io/IoCreateSymbolicLink.c
@@ -76,7 +76,7 @@ void test_IoCreateSymbolicLink()
     };
     size_t device_test_str_size = ARRAY_SIZE(device_test_str);
 
-    print("  Running tests for symbolic link inputs");
+    // Perform tests for symbolic link inputs
     for (unsigned i = 0; i < symlink_test_size; i++) {
         result = IoCreateSymbolicLink(symlink_test_str[i].pStr, &device_str);
         if (result == STATUS_SUCCESS) {
@@ -86,7 +86,7 @@ void test_IoCreateSymbolicLink()
         tests_passed &= assert_NTSTATUS(result, symlink_test_str[i].expected_result, func_name);
     }
 
-    print("  Running tests for device inputs");
+    // Perform tests for device inputs
     for (unsigned i = 0; i < device_test_str_size; i++) {
         result = IoCreateSymbolicLink(&symlink_str, device_test_str[i].pStr);
         if (result == STATUS_SUCCESS) {

--- a/src/tests/rtl/RtlFillMemory.c
+++ b/src/tests/rtl/RtlFillMemory.c
@@ -1,41 +1,40 @@
 #include <xboxkrnl/xboxkrnl.h>
-#include <stdint.h>
 
-#include "global.h" // for (passed|failed)_test vars
 #include "util/output.h"
 #include "util/misc.h"
+#include "assertions/defines.h"
 
 void test_RtlFillMemory()
 {
     const char* func_num = "0x011C";
     const char* func_name = "RtlFillMemory";
-    BOOL tests_passed = 1;
+    BOOL test_passed = 1;
     print_test_header(func_num, func_name);
 
-    const BYTE buf_len = 20;
-    BYTE buffer[buf_len];
-    DWORD lengths[] = {1, 10, buf_len};
-    BYTE fills[] = {0x1, 0x2A, 0xFF};
-    BOOL individual_test_passes = 1;
+    enum { buf_len = 20 };
+    UCHAR buffer[buf_len] = { 0 };
+    UCHAR expected_fills[buf_len] = { 0 };
+
+    typedef struct _fill_test {
+        DWORD length;
+        UCHAR fill;
+    } fill_test;
+
+    fill_test fill_tests[] = {
+        { .length = 1, .fill = 0x1 },
+        { .length = 10, .fill = 0x2A },
+        { .length = buf_len, .fill = 0xFF }
+    };
 
     RtlZeroMemory(buffer, buf_len);
-    for(uint8_t i = 0; i < ARRAY_SIZE(lengths); i++) {
-        const char* result_text = passed_text;
-        RtlFillMemory(buffer, lengths[i], fills[i]);
-        for(uint8_t y = 0; y < buf_len; y++) {
-            BYTE expected_fill = (y < lengths[i]) ? fills[i] : 0x00;
-            if(buffer[y] != expected_fill) {
-                print("  ERROR: For index = %u, got = 0x%x, expected = 0x%x", y, buffer[y], expected_fill);
-                individual_test_passes = 0;
-            }
+    for (unsigned i = 0; i < ARRAY_SIZE(fill_tests); i++) {
+        // setup expected fill array
+        for (unsigned k = 0; k < fill_tests[i].length; k++) {
+            expected_fills[k] = fill_tests[i].fill;
         }
-        if(!individual_test_passes) {
-            tests_passed = 0;
-            result_text = failed_text;
-        }
-        print("  Test %s for length = %u, fill = 0x%x", result_text, lengths[i], fills[i]);
-        individual_test_passes = 1;
+        RtlFillMemory(buffer, fill_tests[i].length * sizeof(UCHAR), fill_tests[i].fill);
+        GEN_CHECK_ARRAY(buffer, expected_fills, buf_len, "fills");
     }
 
-    print_test_footer(func_num, func_name, tests_passed);
+    print_test_footer(func_num, func_name, test_passed);
 }

--- a/src/tests/rtl/RtlFillMemoryUlong.c
+++ b/src/tests/rtl/RtlFillMemoryUlong.c
@@ -1,41 +1,40 @@
 #include <xboxkrnl/xboxkrnl.h>
-#include <stdint.h>
 
-#include "global.h" // for (passed|failed)_test vars
 #include "util/output.h"
 #include "util/misc.h"
+#include "assertions/defines.h"
 
 void test_RtlFillMemoryUlong()
 {
     const char* func_num = "0x011D";
     const char* func_name = "RtlFillMemoryUlong";
-    BOOL tests_passed = 1;
+    BOOL test_passed = 1;
     print_test_header(func_num, func_name);
 
-    const BYTE buf_len = 20;
-    ULONG buffer[buf_len];
-    SIZE_T lengths[] = {1, 10, buf_len};
-    ULONG patterns[] = {0x1, 0x2FFF, 0xFFFFFFFF};
-    BOOL individual_test_passes = 1;
+    enum { buf_len = 20 };
+    ULONG buffer[buf_len] = { 0 };
+    ULONG expected_fills[buf_len] = { 0 };
+
+    typedef struct _fill_test {
+        SIZE_T length;
+        ULONG fill;
+    } fill_test;
+
+    fill_test fill_tests[] = {
+        { .length = 1, .fill = 0x1 },
+        { .length = 10, .fill = 0x2FFF },
+        { .length = buf_len, .fill = 0xFFFFFFFF }
+    };
 
     RtlZeroMemory(buffer, buf_len * sizeof(ULONG));
-    for(uint8_t i = 0; i < ARRAY_SIZE(lengths); i++) {
-        const char* result_text = passed_text;
-        RtlFillMemoryUlong(buffer, lengths[i] * sizeof(ULONG), patterns[i]);
-        for(uint8_t y = 0; y < buf_len; y++) {
-            ULONG expected_pattern = (y < lengths[i]) ? patterns[i] : 0x0;
-            if(buffer[y] != expected_pattern) {
-                print("  ERROR: For index = %u, got = 0x%x, expected = 0x%x", y, buffer[y], expected_pattern);
-                individual_test_passes = 0;
-            }
+    for (unsigned i = 0; i < ARRAY_SIZE(fill_tests); i++) {
+        // setup expected fill array
+        for (unsigned k = 0; k < fill_tests[i].length; k++) {
+            expected_fills[k] = fill_tests[i].fill;
         }
-        if(!individual_test_passes) {
-            tests_passed = 0;
-            result_text = failed_text;
-        }
-        print("  Test %s for length = %u, pattern = 0x%x", result_text, lengths[i], patterns[i]);
-        individual_test_passes = 1;
+        RtlFillMemoryUlong(buffer, fill_tests[i].length * sizeof(ULONG), fill_tests[i].fill);
+        GEN_CHECK_ARRAY(buffer, expected_fills, buf_len, "fills");
     }
 
-    print_test_footer(func_num, func_name, tests_passed);
+    print_test_footer(func_num, func_name, test_passed);
 }

--- a/src/tests/rtl/RtlUlongByteSwap.c
+++ b/src/tests/rtl/RtlUlongByteSwap.c
@@ -1,31 +1,33 @@
 #include <xboxkrnl/xboxkrnl.h>
-#include <stdint.h>
 
-#include "global.h" // for (passed|failed)_test vars
 #include "util/output.h"
 #include "util/misc.h"
+#include "assertions/defines.h"
 
 void test_RtlUlongByteSwap()
 {
     const char* func_num = "0x0133";
     const char* func_name = "RtlUlongByteSwap";
-    BOOL tests_passed = 1;
+    BOOL test_passed = 1;
     print_test_header(func_num, func_name);
 
-    const ULONG inputs[]           = {0xFF00FF00, 0x12345678, 0xD4C3B2A1};
-    const ULONG expected_results[] = {0x00FF00FF, 0x78563412, 0xA1B2C3D4};
-    ULONG result;
+    typedef struct _byte_swap_test {
+        const ULONG input;
+        const ULONG expected_result;
+        ULONG return_result;
+    } byte_swap_test;
 
-    for(uint8_t i = 0; i < ARRAY_SIZE(inputs); i++) {
-        const char* result_text = passed_text;
-        result = RtlUlongByteSwap(inputs[i]);
-        if(result != expected_results[i]) {
-            tests_passed = 0;
-            result_text = failed_text;
-        }
-        print("  Test %s: Expected = 0x%x for Input = 0x%x, Result = 0x%x",
-              result_text, expected_results[i], inputs[i], result);
+    byte_swap_test byte_swap_tests[] = {
+        { .input = 0xFF00FF00, .expected_result = 0x00FF00FF },
+        { .input = 0x12345678, .expected_result = 0x78563412 },
+        { .input = 0xD4C3B2A1, .expected_result = 0xA1B2C3D4 }
+    };
+    unsigned byte_swap_tests_size = ARRAY_SIZE(byte_swap_tests);
+
+    for (unsigned i = 0; i < byte_swap_tests_size; i++) {
+        byte_swap_tests[i].return_result = RtlUlongByteSwap(byte_swap_tests[i].input);
     }
+    GEN_CHECK_ARRAY_MEMBER(byte_swap_tests, return_result, expected_result, byte_swap_tests_size, "byte_swap_tests");
 
-    print_test_footer(func_num, func_name, tests_passed);
+    print_test_footer(func_num, func_name, test_passed);
 }

--- a/src/tests/rtl/RtlUshortByteSwap.c
+++ b/src/tests/rtl/RtlUshortByteSwap.c
@@ -1,31 +1,34 @@
 #include <xboxkrnl/xboxkrnl.h>
-#include <stdint.h>
 
-#include "global.h" // for (passed|failed)_test vars
 #include "util/output.h"
 #include "util/misc.h"
+#include "assertions/defines.h"
 
 void test_RtlUshortByteSwap()
 {
     const char* func_num = "0x013E";
     const char* func_name = "RtlUshortByteSwap";
-    BOOL tests_passed = 1;
+    BOOL test_passed = 1;
     print_test_header(func_num, func_name);
 
-    const USHORT inputs[]           = {0xFF00, 0x00FF, 0x1234, 0xF0E0};
-    const USHORT expected_results[] = {0x00FF, 0xFF00, 0x3412, 0xE0F0};
-    USHORT result;
+    typedef struct _byte_swap_test {
+        const USHORT input;
+        const USHORT expected_result;
+        USHORT return_result;
+    } byte_swap_test;
 
-    for(uint8_t i = 0; i < ARRAY_SIZE(inputs); i++) {
-        const char* result_text = passed_text;
-        result = RtlUshortByteSwap(inputs[i]);
-        if(result != expected_results[i]) {
-            tests_passed = 0;
-            result_text = failed_text;
-        }
-        print("  Test %s: Expected = 0x%x for Input = 0x%x, Result = 0x%x",
-              result_text, expected_results[i], inputs[i], result);
+    byte_swap_test byte_swap_tests[] = {
+        { .input = 0xFF00, .expected_result = 0x00FF },
+        { .input = 0x00FF, .expected_result = 0xFF00 },
+        { .input = 0x1234, .expected_result = 0x3412 },
+        { .input = 0xF0E0, .expected_result = 0xE0F0 }
+    };
+    unsigned byte_swap_tests_size = ARRAY_SIZE(byte_swap_tests);
+
+    for (unsigned i = 0; i < byte_swap_tests_size; i++) {
+        byte_swap_tests[i].return_result = RtlUshortByteSwap(byte_swap_tests[i].input);
     }
+    GEN_CHECK_ARRAY_MEMBER(byte_swap_tests, return_result, expected_result, byte_swap_tests_size, "byte_swap_tests");
 
-    print_test_footer(func_num, func_name, tests_passed);
+    print_test_footer(func_num, func_name, test_passed);
 }

--- a/src/tests/rtl/suite/call_trace.c
+++ b/src/tests/rtl/suite/call_trace.c
@@ -150,8 +150,10 @@ void test_RtlWalkFrameChain()
 
     // Output any remaining parent calls occur from the stack.
     // We do not make any parent calls address verification as they can change at any time.
-    for (ULONG i = 4; i < total; i++) {
-        print("  INFO: callers[%u] = 0x%08x", i, callers[i]);
+    if (!test_passed) {
+        for (ULONG i = 4; i < total; i++) {
+            print("  DEBUG: callers[%u] = 0x%08x", i, callers[i]);
+        }
     }
 
     print_test_footer(func_num, func_name, test_passed);

--- a/src/tests/rtl/suite/comparison.c
+++ b/src/tests/rtl/suite/comparison.c
@@ -1,6 +1,5 @@
 #include <xboxkrnl/xboxkrnl.h>
 #include <stdint.h>
-#include <stdio.h>
 
 #include "util/output.h"
 #include "util/misc.h"
@@ -45,7 +44,7 @@ void test_RtlCompareMemoryUlong()
 {
     const char* func_num = "0x010D";
     const char* func_name = "RtlCompareMemoryUlong";
-    BOOL tests_passed = 1;
+    BOOL test_passed = 1;
     print_test_header(func_num, func_name);
 
     ULONG mem[4];
@@ -55,25 +54,36 @@ void test_RtlCompareMemoryUlong()
     mem[2]= 0x89ab;
     mem[3]= 0xcdef;
 
-    tests_passed &= RtlCompareMemoryUlong(mem, 0, 0x0123) == 0 ? 1 : 0;
-    tests_passed &= RtlCompareMemoryUlong(mem, 3, 0x0123) == 0 ? 1 : 0;
-    tests_passed &= RtlCompareMemoryUlong(mem, 4, 0x0123) == 4 ? 1 : 0;
-    tests_passed &= RtlCompareMemoryUlong(mem, 5, 0x0123) == 4 ? 1 : 0;
-    tests_passed &= RtlCompareMemoryUlong(mem, 7, 0x0123) == 4 ? 1 : 0;
-    tests_passed &= RtlCompareMemoryUlong(mem, 8, 0x0123) == 4 ? 1 : 0;
-    tests_passed &= RtlCompareMemoryUlong(mem, 9, 0x0123) == 4 ? 1 : 0;
-    tests_passed &= RtlCompareMemoryUlong(mem, 4, 0x0127) == 0 ? 1 : 0;
-    tests_passed &= RtlCompareMemoryUlong(mem, 4, 0x7123) == 0 ? 1 : 0;
-    tests_passed &= RtlCompareMemoryUlong(mem, 16, 0x4567) == 0 ? 1 : 0;
+    SIZE_T result;
+    result = RtlCompareMemoryUlong(mem, 0, 0x0123);
+    GEN_CHECK(result, 0, "result");
+    result = RtlCompareMemoryUlong(mem, 3, 0x0123);
+    GEN_CHECK(result, 0, "result");
+    result = RtlCompareMemoryUlong(mem, 4, 0x0123);
+    GEN_CHECK(result, 4, "result");
+    result = RtlCompareMemoryUlong(mem, 5, 0x0123);
+    GEN_CHECK(result, 4, "result");
+    result = RtlCompareMemoryUlong(mem, 7, 0x0123);
+    GEN_CHECK(result, 4, "result");
+    result = RtlCompareMemoryUlong(mem, 8, 0x0123);
+    GEN_CHECK(result, 4, "result");
+    result = RtlCompareMemoryUlong(mem, 9, 0x0123);
+    GEN_CHECK(result, 4, "result");
+    result = RtlCompareMemoryUlong(mem, 4, 0x0127);
+    GEN_CHECK(result, 0, "result");
+    result = RtlCompareMemoryUlong(mem, 4, 0x7123);
+    GEN_CHECK(result, 0, "result");
+    result = RtlCompareMemoryUlong(mem, 16, 0x4567);
+    GEN_CHECK(result, 0, "result");
 
-    print_test_footer(func_num, func_name, tests_passed);
+    print_test_footer(func_num, func_name, test_passed);
 }
 
 void test_RtlCompareString()
 {
     const char* func_num = "0x010E";
     const char* func_name = "RtlCompareString";
-    BOOL tests_passed = 1;
+    BOOL test_passed = 1;
     print_test_header(func_num, func_name);
 
     ANSI_STRING lower_case_string;
@@ -84,14 +94,22 @@ void test_RtlCompareString()
     RtlInitAnsiString(&upper_case_string, "TEST_STRING");
     RtlInitAnsiString(&long_string, "this_is_a_long_string");
 
-    tests_passed &= RtlCompareString(&lower_case_string, &upper_case_string, 1) == 0 ? 1 : 0;
-    tests_passed &= RtlCompareString(&lower_case_string, &upper_case_string, 0) != 0 ? 1 : 0;
-    tests_passed &= RtlCompareString(&lower_case_string, &lower_case_string, 1) == 0 ? 1 : 0;
-    tests_passed &= RtlCompareString(&lower_case_string, &lower_case_string, 0) == 0 ? 1 : 0;
-    tests_passed &= RtlCompareString(&lower_case_string, &long_string, 1) < 0 ? 1 : 0;
-    tests_passed &= RtlCompareString(&long_string, &lower_case_string, 1) > 0 ? 1 : 0;
+    LONG result;
 
-    print_test_footer(func_num, func_name, tests_passed);
+    result = RtlCompareString(&lower_case_string, &upper_case_string, 1);
+    GEN_CHECK(result, 0, "result");
+    result = RtlCompareString(&lower_case_string, &upper_case_string, 0);
+    GEN_CHECK(result, 32, "result");
+    result = RtlCompareString(&lower_case_string, &lower_case_string, 1);
+    GEN_CHECK(result, 0, "result");
+    result = RtlCompareString(&lower_case_string, &lower_case_string, 0);
+    GEN_CHECK(result, 0, "result");
+    result = RtlCompareString(&lower_case_string, &long_string, 1);
+    GEN_CHECK(result, -3, "result");
+    result = RtlCompareString(&long_string, &lower_case_string, 1);
+    GEN_CHECK(result, 3, "result");
+
+    print_test_footer(func_num, func_name, test_passed);
 }
 
 void test_RtlCompareUnicodeString()

--- a/src/tests/rtl/suite/comparison.c
+++ b/src/tests/rtl/suite/comparison.c
@@ -1,9 +1,10 @@
 #include <xboxkrnl/xboxkrnl.h>
 #include <stdint.h>
+#include <stdio.h>
 
-#include "global.h" // for (passed|failed)_test vars
 #include "util/output.h"
 #include "util/misc.h"
+#include "assertions/defines.h"
 #include "assertions/rtl.h"
 
 void test_RtlCompareMemory()
@@ -152,12 +153,17 @@ void test_RtlCompareUnicodeString()
 
     print_test_footer(func_num, func_name, tests_passed);
 }
+static const char* str1_str = "str1";
+static const char* str2_str = "str2";
+static const char* str3_str = "str3";
+static const char* case_insensitive_str = "insensitive";
+static const char* case_sensitive_str = "sensitive";
 
 void test_RtlEqualString()
 {
     const char* func_num = "0x0117";
     const char* func_name = "RtlEqualString";
-    BOOL tests_passed = 1;
+    BOOL test_passed = 1;
     print_test_header(func_num, func_name);
 
     ANSI_STRING str1, str2, str3;
@@ -165,32 +171,37 @@ void test_RtlEqualString()
     RtlInitAnsiString(&str2, "XBOX IS COOL");
     RtlInitAnsiString(&str3, "is xbox cool?");
 
-    ANSI_STRING* str1_inputs[]      = {&str1, &str1, &str1, &str1, &str1, &str1};
-    ANSI_STRING* str2_inputs[]      = {&str1, &str1, &str2, &str2, &str3, &str3};
-    BOOLEAN      case_insensitive[] = {0    , 1    , 0    , 1    , 0    , 1    };
-    BOOLEAN      expected_result[]  = {1    , 1    , 0    , 1    , 0    , 0    };
+    typedef struct _eq_str_test {
+        const char* var_name;
+        ANSI_STRING* str_compare;
+        BOOLEAN case_insensitive;
+        BOOLEAN expected_result;
+        BOOLEAN return_result;
+    } eq_str_test;
 
-    BOOLEAN result;
-    for(uint8_t i = 0; i < ARRAY_SIZE(str1_inputs); i++) {
-        const char* result_text = passed_text;
-        result = RtlEqualString(str1_inputs[i], str2_inputs[i], case_insensitive[i]);
-        if(result != expected_result[i]) {
-            tests_passed = 0;
-            result_text = failed_text;
-        }
-        print("  Test %s for str1 = %s, str2 = %s, case insensitive = %x. Expected = %x, got = %x",
-              result_text, str1_inputs[i]->Buffer, str2_inputs[i]->Buffer, case_insensitive[i], expected_result[i],
-              result);
+    eq_str_test str_tests[] = {
+        { .var_name = str1_str, .str_compare = &str1, .case_insensitive = 0, .expected_result = 1 },
+        { .var_name = str1_str, .str_compare = &str1, .case_insensitive = 1, .expected_result = 1 },
+        { .var_name = str2_str, .str_compare = &str2, .case_insensitive = 0, .expected_result = 0 },
+        { .var_name = str2_str, .str_compare = &str2, .case_insensitive = 1, .expected_result = 1 },
+        { .var_name = str3_str, .str_compare = &str3, .case_insensitive = 0, .expected_result = 0 },
+        { .var_name = str3_str, .str_compare = &str3, .case_insensitive = 1, .expected_result = 0 }
+    };
+    unsigned str_tests_size = ARRAY_SIZE(str_tests);
+
+    for (unsigned i = 0; i < str_tests_size; i++) {
+        str_tests[i].return_result = RtlEqualString(&str1, str_tests[i].str_compare, str_tests[i].case_insensitive);
     }
+    GEN_CHECK_ARRAY_MEMBER(str_tests, return_result, expected_result, str_tests_size, "str_tests");
 
-    print_test_footer(func_num, func_name, tests_passed);
+    print_test_footer(func_num, func_name, test_passed);
 }
 
 void test_RtlEqualUnicodeString()
 {
     const char* func_num = "0x0118";
     const char* func_name = "RtlEqualUnicodeString";
-    BOOL tests_passed = 1;
+    BOOL test_passed = 1;
     print_test_header(func_num, func_name);
 
     UNICODE_STRING str1;
@@ -201,10 +212,28 @@ void test_RtlEqualUnicodeString()
     RtlInitUnicodeString(&str2, L"XBOX IS COOL");
     RtlInitUnicodeString(&str3, L"is xbox cool?");
 
-    tests_passed &= !RtlEqualUnicodeString(&str1, &str2, 0);
-    tests_passed &= RtlEqualUnicodeString(&str1, &str2, 1);
-    tests_passed &= !RtlEqualUnicodeString(&str1, &str3, 1);
-    tests_passed &= !RtlEqualUnicodeString(&str1, &str3, 0);
+    typedef struct _eq_str_test {
+        const char* var_name;
+        UNICODE_STRING* str_compare;
+        BOOLEAN case_insensitive;
+        BOOLEAN expected_result;
+        BOOLEAN return_result;
+    } eq_str_test;
 
-    print_test_footer(func_num, func_name, tests_passed);
+    eq_str_test str_tests[] = {
+        { .var_name = str1_str, .str_compare = &str1, .case_insensitive = 0, .expected_result = 1 },
+        { .var_name = str1_str, .str_compare = &str1, .case_insensitive = 1, .expected_result = 1 },
+        { .var_name = str2_str, .str_compare = &str2, .case_insensitive = 0, .expected_result = 0 },
+        { .var_name = str2_str, .str_compare = &str2, .case_insensitive = 1, .expected_result = 1 },
+        { .var_name = str3_str, .str_compare = &str3, .case_insensitive = 0, .expected_result = 0 },
+        { .var_name = str3_str, .str_compare = &str3, .case_insensitive = 1, .expected_result = 0 }
+    };
+    unsigned str_tests_size = ARRAY_SIZE(str_tests);
+
+    for (unsigned i = 0; i < str_tests_size; i++) {
+        str_tests[i].return_result = RtlEqualUnicodeString(&str1, str_tests[i].str_compare, str_tests[i].case_insensitive);
+    }
+    GEN_CHECK_ARRAY_MEMBER(str_tests, return_result, expected_result, str_tests_size, "str_tests");
+
+    print_test_footer(func_num, func_name, test_passed);
 }

--- a/src/tests/rtl/suite/comparison.c
+++ b/src/tests/rtl/suite/comparison.c
@@ -116,7 +116,7 @@ void test_RtlCompareUnicodeString()
 {
     const char* func_num = "0x010F";
     const char* func_name = "RtlCompareUnicodeString";
-    BOOL tests_passed = 1;
+    BOOL test_passed = 1;
     print_test_header(func_num, func_name);
 
     const BOOL case_sensitive = 0;
@@ -131,45 +131,27 @@ void test_RtlCompareUnicodeString()
 
     result = RtlCompareUnicodeString(&base_str, &base_str, case_sensitive);
     result += RtlCompareUnicodeString(&base_str, &base_str, case_insensitive);
-    if(result != 0) {
-        print("  Comparing a string to itself failed with result: %d", result);
-        tests_passed = 0;
-    }
+    GEN_CHECK(result, 0, "result");
 
     result = RtlCompareUnicodeString(&base_str, &lowercase_base_str, case_sensitive);
-    if( !(result < 0) ) {
-        print("  Case sensitive compare of case mismatching strings failed with result %d", result);
-        tests_passed = 0;
-    }
+    GEN_CHECK(result, -32, "result");
+
     result = RtlCompareUnicodeString(&base_str, &lowercase_base_str, case_insensitive);
-    if(result != 0) {
-        print("  Case insensitive compare of case mismatching strings failed with result %d", result);
-        tests_passed = 0;
-    }
+    GEN_CHECK(result, 0, "result");
 
     result = RtlCompareUnicodeString(&base_str, &shorter_str, case_sensitive);
-    if( !(result > 0) ) {
-        print("  Case sensitive compare of shorter string failed with result %d", result);
-        tests_passed = 0;
-    }
+    GEN_CHECK(result, 4, "result");
+
     result = RtlCompareUnicodeString(&base_str, &shorter_str, case_insensitive);
-    if( !(result > 0) ) {
-        print("  Case insensitive compare of shorter string failed with result %d", result);
-        tests_passed = 0;
-    }
+    GEN_CHECK(result, 4, "result");
 
     result = RtlCompareUnicodeString(&base_str, &longer_str, case_sensitive);
-    if( !(result < 0) ) {
-        print("  Case sensitive compare of longer string failed with result %d", result);
-        tests_passed = 0;
-    }
-    result = RtlCompareUnicodeString(&base_str, &longer_str, case_insensitive);
-    if( !(result < 0) ) {
-        print("  Case insensitive compare of longer string failed with result %d", result);
-        tests_passed = 0;
-    }
+    GEN_CHECK(result, -18, "result");
 
-    print_test_footer(func_num, func_name, tests_passed);
+    result = RtlCompareUnicodeString(&base_str, &longer_str, case_insensitive);
+    GEN_CHECK(result, -18, "result");
+
+    print_test_footer(func_num, func_name, test_passed);
 }
 static const char* str1_str = "str1";
 static const char* str2_str = "str2";

--- a/src/tests/rtl/suite/string_uppercase.c
+++ b/src/tests/rtl/suite/string_uppercase.c
@@ -28,7 +28,7 @@ void test_RtlUpperChar()
 {
     const char* func_num = "0x013C";
     const char* func_name = "RtlUpperChar";
-    BOOL tests_passed = 1;
+    BOOL test_passed = 1;
     print_test_header(func_num, func_name);
 
     // These results are taken from running inputs 0 through 255 on a NTSC Xbox
@@ -50,18 +50,15 @@ void test_RtlUpperChar()
         0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF,
         0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xF7, 0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0x3F,
     };
-    CHAR result;
+    enum { expected_length = ARRAY_SIZE(expected_outputs) };
+    CHAR results[expected_length];
 
-    for(uint16_t i = 0; i < 0x100; i++) {
-        result = RtlUpperChar((CHAR)i);
-        if(result != expected_outputs[i]) {
-            tests_passed = 0;
-            print("  Test FAILED. Input = '%c'(0x%x), result = '%c'(0x%x), expected ='%c'(0x%x)",
-                 (CHAR)i, i, result, (uint8_t)result, expected_outputs[i], (uint8_t)expected_outputs[i]);
-        }
+    for (unsigned i = 0; i < expected_length; i++) {
+        results[i] = RtlUpperChar((CHAR)i);
     }
+    GEN_CHECK_ARRAY(results, expected_outputs, expected_length, "results");
 
-    print_test_footer(func_num, func_name, tests_passed);
+    print_test_footer(func_num, func_name, test_passed);
 }
 
 void test_RtlUpperString()

--- a/src/tests/rtl/suite/string_uppercase.c
+++ b/src/tests/rtl/suite/string_uppercase.c
@@ -6,6 +6,7 @@
 
 #include "global.h" // for seed var
 #include "util/output.h"
+#include "util/misc.h"
 #include "assertions/defines.h"
 
 void test_RtlUpcaseUnicodeChar()
@@ -67,25 +68,28 @@ void test_RtlUpperString()
 {
     const char* func_num = "0x013D";
     const char* func_name = "RtlUpperString";
-    BOOL tests_passed = 1;
+    BOOL test_passed = 1;
     print_test_header(func_num, func_name);
 
     char rnd_letter;
     char rnd_letters[101];
+    char rnd_letters_upper[101];
 
     srand(seed);
-    for(int k=0; k<100; k++){
+    for (int k = 0; k < 100; k++) {
         rnd_letter = "abcdefghijklmnopqrstuvwxyz"[rand() % 26];
         rnd_letters[k] = rnd_letter;
+        rnd_letters_upper[k] = toupper(rnd_letter);
     }
     rnd_letters[100] = '\0';
+    rnd_letters_upper[100] = '\0';
 
     ANSI_STRING src_str;
     ANSI_STRING res_str;
     char res_buf[256];
 
     /* Initialize res_buf so RtlInitAnsiString works correctly */
-    for (int i=0; i<255; i++)
+    for (int i = 0; i < 255; i++)
         res_buf[i] = '0';
     res_buf[255] = 0;
 
@@ -94,47 +98,32 @@ void test_RtlUpperString()
     /* Empty String Test */
     RtlInitAnsiString(&src_str, "");
     RtlUpperString(&res_str, &src_str);
-    tests_passed &= strncmp(res_str.Buffer, "", res_str.Length) == 0 ? 1 : 0;
-    if(!tests_passed)
-        print("RtlUpperString Lowercase String Test Failed");
+    GEN_CHECK(strncmp(res_str.Buffer, "", res_str.Length) == 0, TRUE, "empty");
 
     /* Lowercase String Test */
     RtlInitAnsiString(&src_str, "xbox");
     RtlUpperString(&res_str, &src_str);
-    tests_passed &= strncmp(res_str.Buffer, "XBOX", res_str.Length) == 0 ? 1 : 0;
-    if(!tests_passed)
-        print("RtlUpperString Lowercase String Test Failed");
+    GEN_CHECK(strncmp(res_str.Buffer, "XBOX", res_str.Length) == 0, TRUE, "compare");
 
     /* Lowercase Single Character Test */
     RtlInitAnsiString(&src_str, "x");
     RtlUpperString(&res_str, &src_str);
-    tests_passed &= strncmp(res_str.Buffer, "X", res_str.Length) == 0 ? 1 : 0;
-    if(!tests_passed)
-        print("RtlUpperString Lowercase Single Character Test Failed");
+    GEN_CHECK(strncmp(res_str.Buffer, "X", res_str.Length) == 0, TRUE, "compare");
 
     /* Uppercase Single Character Test */
     RtlInitAnsiString(&src_str, "X");
     RtlUpperString(&res_str, &src_str);
-    tests_passed &= strncmp(res_str.Buffer, "X", res_str.Length) == 0 ? 1 : 0;
-    if(!tests_passed)
-        print("RtlUpperString Uppercase Single Character Test Failed"); 
+    GEN_CHECK(strncmp(res_str.Buffer, "X", res_str.Length) == 0, TRUE, "compare");
 
     /* 100 Lowercase Characters Test */
     RtlInitAnsiString(&src_str, rnd_letters);
     RtlUpperString(&res_str, &src_str);
-    for(int k=0; k<100; k++){
-        if(res_str.Buffer[k] != toupper(rnd_letters[k]))
-            tests_passed = 0;
-    }
-    if(!tests_passed)
-        print("RtlUpperString 100 Lowercase Characters Test Failed");
+    GEN_CHECK_ARRAY(res_str.Buffer, rnd_letters_upper, ARRAY_SIZE(rnd_letters_upper) - 1, "compare");
 
     /* Uppercase String Test */
     RtlInitAnsiString(&src_str, "XBOX");
     RtlUpperString(&res_str, &src_str);
-    tests_passed &= strncmp(res_str.Buffer, "XBOX", res_str.Length) == 0 ? 1 : 0;
-    if(!tests_passed)
-        print("RtlUpperString Uppercase String Test Failed");
+    GEN_CHECK(strncmp(res_str.Buffer, "XBOX", res_str.Length) == 0, TRUE, "compare");
 
-    print_test_footer(func_num, func_name, tests_passed);
+    print_test_footer(func_num, func_name, test_passed);
 }


### PR DESCRIPTION
The changes are absolutely necessary in order to include line number of where the fault occur at. Plus remove individual test's passing verbose to only when comparison failure occur. Doing so will require update each tests that are affected.

The only remaining `print(...)` calls are:
- debug message:
   - AvSendTVEncoderOption (currently disabled)
   - AvSetDisplayMode (currently disabled)
   - ExAcquireReadWriteLockExclusive (require resolve in separate pull request)
   - ExAcquireReadWriteLockShared (require resolve in separate pull request)
- error message for unable allocate memory:
  - RtlMoveMemory
  - RtlZeroMemory
  - RtlAnsiStringToUnicodeString

Partial fix by #6 which include build hash at this time.

> [!NOTE]
> A few tests has been changed to use direct comparison such as:
> - RtlCompareString
> - RtlCompareUnicodeString
>
> Do expect failures for above tests, although I did made an update to cxbxr's kernel implements to properly return expected value.