### PR TITLE
Fixed initialization order of output file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -112,8 +112,8 @@ void main(void){
     pb_show_debug_screen();
 
     vector_init(&tests_to_run);
-    load_conf_file("D:\\config.txt");
     open_output_file("D:\\kernel_tests.log");
+    load_conf_file("D:\\config.txt");
 
     print("Kernel Test Suite");
     print("build: " GIT_VERSION);


### PR DESCRIPTION
I noticed that the test suite is currently attempting to write to the output file even before it's created. It happens from the function `load_conf_file`, which internally has a call to `print`, which in turn attempts to write to the output file with `write_to_output_file`. But at that point it doesn't yet exist, because the call to `open_output_file` that creates it only happens after `load_conf_file` has finished. So basically, it just needs to swap the order of those two calls