### PR TITLE
Add Output Video Option

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,7 +1,6 @@
-#include <hal/debug.h>
 #include <pbkit/pbkit.h>
-#include <hal/video.h>
-#include <hal/xbox.h>
+#include <hal/video.h> // for XVideoSetMode
+#include <hal/xbox.h> // for XReboot
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -30,26 +29,26 @@ int load_conf_file(char *file_path)
         FILE_ATTRIBUTE_NORMAL,
         NULL
     );
-    if(handle == INVALID_HANDLE_VALUE) {
+    if (handle == INVALID_HANDLE_VALUE) {
         print("Could not open config file '%s' for read", file_path);
         return -1;
     }
 
     DWORD file_size = GetFileSize(handle, NULL);
-    if(file_size == INVALID_FILE_SIZE) {
+    if (file_size == INVALID_FILE_SIZE) {
         print("ERROR: Could not get file size for %s", file_path);
         return -1;
     }
 
     char* buffer = (char *)malloc(file_size);
-    if(buffer == NULL) {
+    if (buffer == NULL) {
         print("Malloc failed for file_size %u", file_size);
         return -1;
     }
 
     DWORD bytes_read = 0;
     BOOL result = ReadFile(handle, buffer, file_size, &bytes_read, NULL);
-    if(result == 0 || bytes_read != file_size) {
+    if (result == 0 || bytes_read != file_size) {
         print("Read failed for config file. result = %d, read = %u", file_size, bytes_read);
         return -1;
     }
@@ -58,15 +57,15 @@ int load_conf_file(char *file_path)
 
     char *line;
     char *rest = buffer;
-    while ((line = strtok_r(rest, "\n", &rest))){
+    while ((line = strtok_r(rest, "\n", &rest))) {
         char *current_key = strtok(line, "=");
-        if(strcmp("seed", current_key) == 0){
+        if (strcmp("seed", current_key) == 0) {
             seed = strtoul(strtok(NULL, "\n"), NULL, 16);
         }
-        if(strcmp("tests", current_key) == 0){
+        if (strcmp("tests", current_key) == 0) {
             char *current_test;
             char *tests = strtok(NULL, "\n");
-            while((current_test = strtok_r(tests, ",", &tests))) {
+            while ((current_test = strtok_r(tests, ",", &tests))) {
                 vector_append(&tests_to_run, strtol(current_test, NULL, 16));
             }
         }
@@ -79,29 +78,30 @@ int load_conf_file(char *file_path)
 static void run_tests()
 {
     print("Random seed used is %u", seed);
-    if(tests_to_run.size == 0) {
+    if (tests_to_run.size == 0) {
         print("No Specific tests specified. Running all tests (Single Pass).");
         print("-------------------------------------------------------------");
         int table_size = ARRAY_SIZE(kernel_thunk_table);
-        for(int k=0;k<table_size;k++){
+        for (int k=0; k<table_size; k++) {
             kernel_thunk_table[k]();
         }
     }
-    else{
+    else {
         print("Config File Was Loaded. Only running requested tests.");
         print("-----------------------------------------------------");
-        for(int k=0; k<tests_to_run.size; k++){
+        for (int k=0; k<tests_to_run.size; k++) {
             kernel_thunk_table[vector_get(&tests_to_run, k)]();
         }
     }
     print("------------------------ End of Tests -----------------------");
 }
 
-void main(void){
+void main(void)
+{
 
     XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
 
-    switch(pb_init()){
+    switch (pb_init()) {
         case 0: break;
         default:
             Sleep(2000);
@@ -118,7 +118,6 @@ void main(void){
     print("Kernel Test Suite");
     print("build: " GIT_VERSION);
     run_tests();
-
 
     vector_free(&tests_to_run);
     close_output_file();

--- a/src/util/output.h
+++ b/src/util/output.h
@@ -8,6 +8,6 @@ void print_test_footer(const char*, const char*, BOOL);
 
 // Real hardware can only display one screen of text at a time. Create an output
 // logfile to contain information for all tests.
-void open_output_file(char*);
+BOOL open_output_file(char*);
 int write_to_output_file(void*, DWORD);
-BOOL close_output_file();
+void close_output_file();


### PR DESCRIPTION
I got annoyed by no space in statements. So I made the fix format commit first.

Since open log file and read config file needs to be done first. Any print calls to screen are require to be disable first until read from config file. Then make the output video default to true if `disable-video` key was not given or set to respective value.

~~I'm currently mark this pull request as draft to verify team's approval to move forward with. Otherwise, I could make video output to always false which will require contributors/testers to use config file.~~

---
In `config.txt` file:
`disable-video=<boolean, 1 or 0 number only>`