### PR TITLE
Additional Log Info Support

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -26,6 +26,8 @@ static void init_default_values()
     output_video = TRUE;
 }
 
+static char *submitter = NULL;
+
 int load_conf_file(char *file_path)
 {
     print("Trying to open config file: %s", file_path);
@@ -83,6 +85,12 @@ int load_conf_file(char *file_path)
         if (strcmp("disable-video", current_key) == 0) {
             output_video = !strtoul(strtok(NULL, "\n"), NULL, 16);
         }
+        if (strcmp("submitter", current_key) == 0) {
+            char *value = strtok(NULL, "\n");
+            size_t length = strlen(value);
+            submitter = calloc(length + 1, sizeof(char));
+            strncpy(submitter, value, length);
+        }
     }
 
     free(buffer);
@@ -133,6 +141,11 @@ void main(void)
 
     print("Kernel Test Suite");
     print("build: " GIT_VERSION);
+    print("submitter: %s", (submitter ? submitter : ""));
+    if (submitter) {
+        free(submitter);
+        submitter = NULL;
+    }
     run_tests();
 
     vector_free(&tests_to_run);

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <windows.h>
 
+#include "util/hardware.h"
 #include "util/output.h"
 #include "util/misc.h"
 #include "util/vector.h"
@@ -146,6 +147,15 @@ void main(void)
         free(submitter);
         submitter = NULL;
     }
+    print("kernel: %hu.%hu.%hu.%hu",
+          XboxKrnlVersion.Major,
+          XboxKrnlVersion.Minor,
+          XboxKrnlVersion.Build,
+          XboxKrnlVersion.Qfe);
+    print("hardware info: flags = 0x%08X, GPU rev = %hhu, MCPX rev = %hhu",
+          XboxHardwareInfo.Flags,
+          XboxHardwareInfo.GpuRevision,
+          XboxHardwareInfo.McpRevision);
     run_tests();
 
     vector_free(&tests_to_run);

--- a/src/main.c
+++ b/src/main.c
@@ -156,6 +156,9 @@ void main(void)
           XboxHardwareInfo.Flags,
           XboxHardwareInfo.GpuRevision,
           XboxHardwareInfo.McpRevision);
+    char pic_version[4];
+    getPICVersion(pic_version);
+    print("PIC version: %s (%s)", pic_version, getConsoleType(pic_version));
     run_tests();
 
     vector_free(&tests_to_run);

--- a/src/util/hardware.h
+++ b/src/util/hardware.h
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: none
+// SPDX-License-Identifier: CC0-1.0
+#pragma once
+
+#include <xboxkrnl/xboxkrnl.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "util/output.h"
+
+static inline uint32_t inl(uint16_t port)
+{
+    uint32_t ret;
+    __asm__ __volatile__("inl %w1, %0"
+                         : "=a"(ret)
+                         : "Nd"(port));
+    return ret;
+}
+
+static void getPICVersion(char pic_version[4])
+{
+    ULONG version;
+    HalWriteSMBusValue(0x20, 0x01, FALSE, 0); // reset index to 0 for reading
+    for (unsigned i = 0; i < 3; i++) {
+        HalReadSMBusValue(0x20, 0x01, 0, &version);
+        pic_version[i] = (char)version;
+    }
+    pic_version[3] = '\0';
+}
+
+static const char* getConsoleType(char pic_version[4])
+{
+    // See https://xboxdevwiki.net/Xboxen_Info
+    if (pic_version[0] == 'A') {
+        return "PROTOTYPE (UNKNOWN)";
+    }
+    else if (pic_version[0] == 'D' || pic_version[0] == 'B') {
+        if (XboxHardwareInfo.Flags & XBOX_HW_FLAG_DEVKIT_KERNEL) {
+            return "DEVKIT or DEBUGKIT";
+        }
+        if (XboxHardwareInfo.Flags & XBOX_HW_FLAG_ARCADE) {
+            // Base on Cxbx-Reloaded's chihiro lpc reader function.
+            uint32_t type = inl(0x40F0); // Media Board Type reader
+            if (type == 0x0000) {
+                return "CHIHIRO (Type-1)";
+            }
+            else if (type == 0x0100) {
+                return "CHIHIRO (Type-3)";
+            }
+
+            print("ERROR: Unknown return type from chihiro hardware: %08X", type);
+            return "CHIHIRO (UNKNOWN)";
+        }
+    }
+    else if (pic_version[0] == 'P') {
+        if (strcmp(pic_version + 1, "01") == 0) {
+            return "Retail 1.0";
+        }
+        if (strcmp(pic_version + 1, "05") == 0) {
+            return "Retail 1.1";
+        }
+        if (strcmp(pic_version + 1, "11") == 0) {
+            // NOTE: 0xD4 is Focus (1.4) video encoder software address.
+            ULONG dummy_storage;
+            if (HalReadSMBusValue(0xD4, 0x00, 0, &dummy_storage) == STATUS_SUCCESS) {
+                return "Retail 1.4";
+            }
+            // TODO: Find out how to tell the difference between 1.2 and 1.3 revisions...
+            return "Retail 1.2 or 1.3";
+        }
+        if (strcmp(pic_version + 1, "2L") == 0) {
+            return "Retail 1.6";
+        }
+    }
+
+    return "UNKNOWN";
+}


### PR DESCRIPTION
## What's already upstreamed:
- build hash

## From this pull request:
- [X] Submitter
- [X] bios/kernel version
- [X] Xbox hardware info flag (helpful to see detail of what kernel sets to)
- [X] PIC version (including console type prediction)
- Xbox hardware revision:
  - [X] GPU (PCI)
  - [X] MCPX (PCI)

## Undecided:
- [ ] Name and/or description (created pull request #98)

## What will not be included:
- Run timestamp
- Used emulator + version / build hash + relevant settings

---

For any missing details, such as hardware revision, please discuss in #6 ticket. Thanks!