### PR TITLE
Add exclude tests option

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -1,7 +1,4 @@
-#include "util/vector.h"
-
 const char* failed_text = "FAILED";
 const char* passed_text = "PASSED";
 
 unsigned int seed = 0;
-vector tests_to_run;

--- a/src/global.h
+++ b/src/global.h
@@ -1,11 +1,8 @@
 #pragma once
 
-#include "util/vector.h"
-
 #define NV2A_MMIO_BASE 0xFD000000
 
 extern const char* failed_text;
 extern const char* passed_text;
 
 extern unsigned int seed;
-extern vector tests_to_run;

--- a/src/include/func_table.h
+++ b/src/include/func_table.h
@@ -410,3 +410,5 @@ void (*kernel_thunk_table[])(void) =
 	test_MmDbgReleaseAddress,                                    // 0x017A (377) DEVKIT
 	test_MmDbgWriteCheck,                                        // 0x017A (378) DEVKIT
 };
+
+static const int kernel_thunk_table_size = ARRAY_SIZE(kernel_thunk_table);

--- a/src/main.c
+++ b/src/main.c
@@ -34,6 +34,8 @@ static void init_default_values()
 
 static char *submitter = NULL;
 
+static vector tests_to_run;
+
 int load_conf_file(char *file_path)
 {
     print("Trying to open config file: %s", file_path);
@@ -110,14 +112,14 @@ static void run_tests()
         print("No Specific tests specified. Running all tests (Single Pass).");
         print("-------------------------------------------------------------");
         int table_size = ARRAY_SIZE(kernel_thunk_table);
-        for (int k=0; k<table_size; k++) {
+        for (int k = 0; k < table_size; k++) {
             kernel_thunk_table[k]();
         }
     }
     else {
         print("Config File Was Loaded. Only running requested tests.");
         print("-----------------------------------------------------");
-        for (int k=0; k<tests_to_run.size; k++) {
+        for (int k = 0; k < tests_to_run.size; k++) {
             kernel_thunk_table[vector_get(&tests_to_run, k)]();
         }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -133,13 +133,13 @@ static void run_tests()
     if (tests_to_run.size == 0) {
         print("No specific tests were requested. Running all tests (Single Pass).");
         if (tests_exclude.size) {
-            int remainder_size = 0;
+            int exclude_count = 0;
             for (int i = 0; i < tests_exclude.size; i++) {
                 if (kernel_thunk_table_size > vector_get(&tests_exclude, i)) {
-                    remainder_size++;
+                    exclude_count++;
                 }
             }
-            print("%d test(s) will be exclude.", remainder_size);
+            print("%d test(s) will be excluded.", exclude_count);
         }
         print("-------------------------------------------------------------");
         for (int k = 0; k < kernel_thunk_table_size; k++) {
@@ -149,17 +149,17 @@ static void run_tests()
     else {
         print("A config file was loaded. Only running requested tests.");
         if (tests_exclude.size) {
-            int remainder_size = 0;
+            int exclude_count = 0;
             for (int k = 0; k < tests_to_run.size; k++) {
                 int test_n = vector_get(&tests_to_run, k);
                 for (int i = 0; i < tests_exclude.size; i++) {
                     if (test_n == vector_get(&tests_exclude, i)) {
-                        remainder_size++;
+                        exclude_count++;
                         break;
                     }
                 }
             }
-            print("%d test(s) will be exclude.", remainder_size);
+            print("%d test(s) will be excluded.", exclude_count);
         }
         print("-----------------------------------------------------");
         for (int k = 0; k < tests_to_run.size; k++) {

--- a/src/util/vector.c
+++ b/src/util/vector.c
@@ -7,10 +7,10 @@
 // This vector implementation is greatly inspired from a tutorial by hbs
 // Ref: https://www.happybearsoftware.com/implementing-a-dynamic-array
 
-void vector_init(vector *vec)
+void vector_init(vector *vec, int capacity)
 {
     vec->size = 0;
-    vec->capacity = 379;
+    vec->capacity = capacity;
     vec->data = malloc(sizeof(int) * vec->capacity);
 }
 

--- a/src/util/vector.h
+++ b/src/util/vector.h
@@ -9,7 +9,7 @@ typedef struct {
   int *data;
 } vector;
 
-void vector_init(vector *vec);
+void vector_init(vector *vec, int capacity);
 void vector_append(vector *vec, int value);
 int vector_get(vector *vec, int index);
 void vector_set(vector *vec, int index, int value);


### PR DESCRIPTION
I recently realize exclude tests will be very useful for emulators to skip them if they are not compatible or aren't working by design. Exclude tests become necessary to verify other test results instead of manually inputting many individual tests, just to remove one or some tests.

---
In `config.txt` file:
`tests-exclude=<export hex number>[,...]`