### PR TITLE
Add name option in a separate file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -66,6 +66,7 @@ void load_name_file(const char* file_path)
     DWORD bytes_read = 0;
     BOOL result = ReadFile(handle, buffer, file_size, &bytes_read, NULL);
     if (result == 0 || bytes_read != file_size) {
+        free(buffer);
         return;
     }
 
@@ -120,6 +121,7 @@ int load_conf_file(char *file_path)
     BOOL result = ReadFile(handle, buffer, file_size, &bytes_read, NULL);
     if (result == 0 || bytes_read != file_size) {
         print("Read failed for config file. result = %d, read = %u", file_size, bytes_read);
+        free(buffer);
         return -1;
     }
 


### PR DESCRIPTION
Instead of add name option in config.txt file, I decided to use it in name.txt file for the following reasons:
1) Ability not need to re-edit config.txt file for each machine every time. This way, config file can be edit once and send to all machines to run the tests to get results back for the reason below.
2) Ability to name kernel_tests.log to a custom suffix name log. i.e. without name.txt file would be `kernel_tests.log` by default. With name.txt file will use `kernel_tests-<name>.log`. This allow for testers to download from all machines into same folder than download individual log files renamed to what machine was used.
3) Profit??

---
In `name.txt` file:
`<name (first line only)>`