### PR TITLE
Update README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,61 @@
 # xbox kernel test suite
-Xbox kernel APIs tester written using the opensoure nxdk
+[![License: GPL v2](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/blob/master/LICENSE)
+[![GitHub CI](https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/actions/workflows/ci.yml?query=branch%3Amaster)
 
-This is a tool for testing xbox kernel apis, in particular CxBx-Reloaded kernel implementation.
+Xbox kernel APIs tester written using the open-source nxdk.
 
-# HOW TO BUILD:
-All you need is nxdk. You can get it here: https://github.com/xqemu/nxdk
+This is a tool for testing the xbox kernel APIs on the hardware to verify tests are passing. Plus we have a dedicated wiki page for [homebrew kernels](https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/wiki/List-of-Homebrew-Kernels-Tested) have used this tool to test their kernel implementation.
 
-Here is a setup guide: https://github.com/xqemu/nxdk/wiki/Getting-Started
+## HOW TO BUILD:
+All you need is nxdk. You can get it here: https://github.com/XboxDev/nxdk
 
-# CONFIGURATION FILE:
-The configuration file should be called _**"config.txt"**_ and should be placed in the same directory of the xbe.
+Here is a setup guide: https://github.com/XboxDev/nxdk/wiki/Getting-Started
 
-This is an example of config.txt:
+## CONFIGURATION FILE:
+> [!NOTE]
+> The configuration file should be called _**"config.txt"**_ and should be placed in the same directory of the xbe.
 
-```
-seed=5
+The following list of options can be used inside config.txt file:
+- `seed` = `<hexadecimal (support up to unsigned int max)>`
+- `tests` = `<hexadecimal (support up to 17A)>[,...]`
+- `tests-exclude` = `<hexadecimal (support up to 17A)>[,...]`
+- `disable-video` = `<boolean>`[^1]
 
-tests=1,25,3,F
-```
+[^1]: boolean value can be 1 or 0
 
-**PAY ATTENTION:** Every value is treated as hex (eg. 25 is 37 in decimal)
+> [!TIP]
+> This is an example of config.txt:
+> ```
+> seed=5
+> 
+> tests=1,25,3,F
+> ```
 
-# BINARIES:
+## NAME FILE:
+> [!NOTE]
+> The name file should be called _**"name.txt"**_ and should be placed in the same directory of the xbe.
+
+Having a name file can help generate individual log files for different hardware and emulators to collect results in the same folder without the need to rename log files every time.
+
+> [!TIP]
+> This is an example of name.txt:
+> ```
+> retail 1.6
+> ```
+
+## BINARIES:
 You can download pre-built bins from here: https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/releases
 
-# GITHUB CI:
-Current build status can be seen here: https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/actions/workflows/ci.yml
-
-# USEFUL LINKS:
+## USEFUL LINKS:
+* https://xboxdevwiki.net
 * https://github.com/wine-mirror/wine/tree/master/dlls/ntdll/tests
 * https://github.com/wine-mirror/wine/tree/master/dlls/kernel32/tests
 * https://github.com/mirror/reactos/tree/master/rostests/apitests/kernel32
 * https://github.com/mborgerson/xbtests?files=1
 * https://github.com/wine-mirror/wine/blob/master/include/wine/test.h
 
-# TODO:
-* Complete the test suite with all xbox kernel APIs (fill the stubs)
-* Organize the code, maybe using folders etc.
+## TODO:
+* Complete the test suite with all xbox kernel APIs (fill in the FIXME stubs).
+* Check the [opened issues](https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/issues) for any issues or tasks.
 
 ANY HELP IS REALLY WELCOME!

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Xbox kernel APIs tester written using the open-source nxdk.
 
-This is a tool for testing the xbox kernel APIs on the hardware to verify tests are passing. Plus we have a dedicated wiki page for [homebrew kernels](https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/wiki/List-of-Homebrew-Kernels-Tested) have used this tool to test their kernel implementation.
+This is a tool for testing the xbox kernel APIs on the hardware to verify their workings. In addition, we have a dedicated wiki page for [homebrew kernels](https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/wiki/List-of-Homebrew-Kernels-Tested) that have used this tool to test their kernel implementation.
 
 ## HOW TO BUILD:
 All you need is nxdk. You can get it here: https://github.com/XboxDev/nxdk
@@ -15,8 +15,8 @@ Here is a setup guide: https://github.com/XboxDev/nxdk/wiki/Getting-Started
 > [!NOTE]
 > The configuration file should be called _**"config.txt"**_ and should be placed in the same directory of the xbe.
 
-The following list of options can be used inside config.txt file:
-- `seed` = `<hexadecimal (support up to unsigned int max)>`
+The following list of options can be used inside the config.txt file:
+- `seed` = `<hexadecimal (support up to FFFFFFFF)>`
 - `tests` = `<hexadecimal (support up to 17A)>[,...]`
 - `tests-exclude` = `<hexadecimal (support up to 17A)>[,...]`
 - `disable-video` = `<boolean>`[^1]


### PR DESCRIPTION
Major updates to the readme file:
- Fixed headers to reduce font size a bit.
- Added license and CI build state badges at the top.
- Added all available options can be done in config and name files with details.
- Updated all of the outdated links.
- Updated top description to no longer refer to Cxbx-Reloaded only. This xbox kernel test suite tool can be tested for any homebrew kernels. Plus a link to wiki page for homebrew kernel creators to add themselves without relying on pull requests and not to bloat the readme file for current and future homebrew kernels.