### PR TITLE
Use decimal instead of hex for the test numbers and the seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Here is a setup guide: https://github.com/XboxDev/nxdk/wiki/Getting-Started
 > The configuration file should be called _**"config.txt"**_ and should be placed in the same directory of the xbe.
 
 The following list of options can be used inside the config.txt file:
-- `seed` = `<hexadecimal (support up to FFFFFFFF)>`
-- `tests` = `<hexadecimal (support up to 17A) or case insensitive API name>[,...]`
-- `tests-exclude` = `<hexadecimal (support up to 17A) or case insensitive API name>[,...]`
+- `seed` = `<decimal (support up to 4294967295)>`
+- `tests` = `<decimal (support up to 378) or case insensitive API name>[,...]`
+- `tests-exclude` = `<decimal (support up to 378) or case insensitive API name>[,...]`
 - `disable-video` = `<boolean>`[^1]
 
 [^1]: boolean value can be 1 or 0
@@ -28,7 +28,7 @@ The following list of options can be used inside the config.txt file:
 > ```
 > seed=5
 > 
-> tests=1,25,3,F,NtReadFile
+> tests=1,25,3,NtReadFile
 > ```
 
 ## NAME FILE:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,7 +107,7 @@ unsigned long convert_test_api_input(char* test_str) {
         return ULONG_MAX;
     }
     // Otherwise, we assumed the input is a hexadecimal string.
-    return strtoul(test_str, NULL, 16);
+    return strtoul(test_str, NULL, 10);
 }
 
 int load_conf_file(const char *file_path)
@@ -156,7 +156,7 @@ int load_conf_file(const char *file_path)
     while ((line = strtok_r(rest, NEWLINE_DELIMITER, &rest))) {
         char *current_key = strtok(line, "=");
         if (strcmp("seed", current_key) == 0) {
-            seed = strtoul(strtok(NULL, NEWLINE_DELIMITER), NULL, 16);
+            seed = strtoul(strtok(NULL, NEWLINE_DELIMITER), NULL, 10);
         }
         if (strcmp("tests", current_key) == 0) {
             char *current_test;
@@ -179,7 +179,7 @@ int load_conf_file(const char *file_path)
             }
         }
         if (strcmp("disable-video", current_key) == 0) {
-            output_video = !strtoul(strtok(NULL, NEWLINE_DELIMITER), NULL, 16);
+            output_video = !strtoul(strtok(NULL, NEWLINE_DELIMITER), NULL, 10);
         }
         if (strcmp("submitter", current_key) == 0) {
             char *value = strtok(NULL, NEWLINE_DELIMITER);

--- a/src/util/output.c
+++ b/src/util/output.c
@@ -46,7 +46,7 @@ void print_test_header(
     int api_num,
     const char* api_name)
 {
-    print("0x%04X - %s: Tests Starting", api_num, api_name);
+    print("%03u - %s: Tests Starting", api_num, api_name);
 }
 
 void print_test_footer(
@@ -55,10 +55,10 @@ void print_test_footer(
     BOOL tests_passed)
 {
     if(tests_passed) {
-        print("0x%04X - %s: All tests PASSED", api_num, api_name);
+        print("%03u - %s: All tests PASSED", api_num, api_name);
     }
     else {
-        print("0x%04X - %s: One or more tests FAILED", api_num, api_name);
+        print("%03u - %s: One or more tests FAILED", api_num, api_name);
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/issues/107. Note that this will require users to update their `config.txt` file to use decimal instead of hex.