### PR TITLE
Implement tests for (Nt|Ke)(Resume|Suspend)Thread APIs

### DIFF
--- a/src/tests/ke/KeAlertResumeThread.c
+++ b/src/tests/ke/KeAlertResumeThread.c
@@ -1,8 +1,0 @@
-#include <xboxkrnl/xboxkrnl.h>
-
-#include "util/output.h"
-
-TEST_FUNC(KeAlertResumeThread)
-{
-    /* FIXME: This is a stub! implement this function! */
-}

--- a/src/tests/ke/KeAlertThread.c
+++ b/src/tests/ke/KeAlertThread.c
@@ -1,8 +1,0 @@
-#include <xboxkrnl/xboxkrnl.h>
-
-#include "util/output.h"
-
-TEST_FUNC(KeAlertThread)
-{
-    /* FIXME: This is a stub! implement this function! */
-}

--- a/src/tests/ke/KeBoostPriorityThread.c
+++ b/src/tests/ke/KeBoostPriorityThread.c
@@ -1,8 +1,0 @@
-#include <xboxkrnl/xboxkrnl.h>
-
-#include "util/output.h"
-
-TEST_FUNC(KeBoostPriorityThread)
-{
-    /* FIXME: This is a stub! implement this function! */
-}

--- a/src/tests/ke/KeDelayExecutionThread.c
+++ b/src/tests/ke/KeDelayExecutionThread.c
@@ -1,8 +1,0 @@
-#include <xboxkrnl/xboxkrnl.h>
-
-#include "util/output.h"
-
-TEST_FUNC(KeDelayExecutionThread)
-{
-    /* FIXME: This is a stub! implement this function! */
-}

--- a/src/tests/ke/KeGetCurrentThread.c
+++ b/src/tests/ke/KeGetCurrentThread.c
@@ -1,8 +1,0 @@
-#include <xboxkrnl/xboxkrnl.h>
-
-#include "util/output.h"
-
-TEST_FUNC(KeGetCurrentThread)
-{
-    /* FIXME: This is a stub! implement this function! */
-}

--- a/src/tests/ke/KeQueryBasePriorityThread.c
+++ b/src/tests/ke/KeQueryBasePriorityThread.c
@@ -1,8 +1,0 @@
-#include <xboxkrnl/xboxkrnl.h>
-
-#include "util/output.h"
-
-TEST_FUNC(KeQueryBasePriorityThread)
-{
-    /* FIXME: This is a stub! implement this function! */
-}

--- a/src/tests/ke/KeResumeThread.c
+++ b/src/tests/ke/KeResumeThread.c
@@ -1,8 +1,0 @@
-#include <xboxkrnl/xboxkrnl.h>
-
-#include "util/output.h"
-
-TEST_FUNC(KeResumeThread)
-{
-    /* FIXME: This is a stub! implement this function! */
-}

--- a/src/tests/ke/KeSetBasePriorityThread.c
+++ b/src/tests/ke/KeSetBasePriorityThread.c
@@ -1,8 +1,0 @@
-#include <xboxkrnl/xboxkrnl.h>
-
-#include "util/output.h"
-
-TEST_FUNC(KeSetBasePriorityThread)
-{
-    /* FIXME: This is a stub! implement this function! */
-}

--- a/src/tests/ke/KeSetDisableBoostThread.c
+++ b/src/tests/ke/KeSetDisableBoostThread.c
@@ -1,8 +1,0 @@
-#include <xboxkrnl/xboxkrnl.h>
-
-#include "util/output.h"
-
-TEST_FUNC(KeSetDisableBoostThread)
-{
-    /* FIXME: This is a stub! implement this function! */
-}

--- a/src/tests/ke/KeSetPriorityThread.c
+++ b/src/tests/ke/KeSetPriorityThread.c
@@ -1,8 +1,0 @@
-#include <xboxkrnl/xboxkrnl.h>
-
-#include "util/output.h"
-
-TEST_FUNC(KeSetPriorityThread)
-{
-    /* FIXME: This is a stub! implement this function! */
-}

--- a/src/tests/ke/KeSuspendThread.c
+++ b/src/tests/ke/KeSuspendThread.c
@@ -1,8 +1,0 @@
-#include <xboxkrnl/xboxkrnl.h>
-
-#include "util/output.h"
-
-TEST_FUNC(KeSuspendThread)
-{
-    /* FIXME: This is a stub! implement this function! */
-}

--- a/src/tests/ke/KeTestAlertThread.c
+++ b/src/tests/ke/KeTestAlertThread.c
@@ -1,8 +1,0 @@
-#include <xboxkrnl/xboxkrnl.h>
-
-#include "util/output.h"
-
-TEST_FUNC(KeTestAlertThread)
-{
-    /* FIXME: This is a stub! implement this function! */
-}

--- a/src/tests/ke/suite/thread.c
+++ b/src/tests/ke/suite/thread.c
@@ -1,0 +1,63 @@
+#include <xboxkrnl/xboxkrnl.h>
+
+#include "util/output.h"
+
+TEST_FUNC(KeAlertResumeThread)
+{
+    /* FIXME: This is a stub! implement this function! */
+}
+
+TEST_FUNC(KeAlertThread)
+{
+    /* FIXME: This is a stub! implement this function! */
+}
+
+TEST_FUNC(KeBoostPriorityThread)
+{
+    /* FIXME: This is a stub! implement this function! */
+}
+
+TEST_FUNC(KeDelayExecutionThread)
+{
+    /* FIXME: This is a stub! implement this function! */
+}
+
+TEST_FUNC(KeGetCurrentThread)
+{
+    /* FIXME: This is a stub! implement this function! */
+}
+
+TEST_FUNC(KeQueryBasePriorityThread)
+{
+    /* FIXME: This is a stub! implement this function! */
+}
+
+TEST_FUNC(KeResumeThread)
+{
+    /* FIXME: This is a stub! implement this function! */
+}
+
+TEST_FUNC(KeSetBasePriorityThread)
+{
+    /* FIXME: This is a stub! implement this function! */
+}
+
+TEST_FUNC(KeSetDisableBoostThread)
+{
+    /* FIXME: This is a stub! implement this function! */
+}
+
+TEST_FUNC(KeSetPriorityThread)
+{
+    /* FIXME: This is a stub! implement this function! */
+}
+
+TEST_FUNC(KeSuspendThread)
+{
+    /* FIXME: This is a stub! implement this function! */
+}
+
+TEST_FUNC(KeTestAlertThread)
+{
+    /* FIXME: This is a stub! implement this function! */
+}

--- a/src/tests/ke/suite/thread.c
+++ b/src/tests/ke/suite/thread.c
@@ -1,6 +1,186 @@
 #include <xboxkrnl/xboxkrnl.h>
+#include <processthreadsapi.h> // for CreateThread
+#include <stdio.h> // for snprintf
+#include <excpt.h> // for __try/__except
 
 #include "util/output.h"
+#include "util/misc.h"
+#include "util/thread.h"
+#include "util/exception.h"
+#include "assertions/defines.h"
+
+// TODO: Add below into nxdk's xboxkrnl/ntstatus.h file
+#define STATUS_SUSPEND_COUNT_EXCEEDED 0xC000004A
+
+typedef struct {
+    BOOL terminate;
+    ULONG counter;
+    HANDLE hEventThread;
+    HANDLE hEventMain;
+} thread_sync_counter_s;
+
+typedef ULONG (NTAPI *threadFuncAPI) (PKTHREAD);
+
+typedef struct _thread_test {
+    // Previous status check
+    BOOL addThreadCounter;        // 0 or 1
+    NTSTATUS expected_statusWait; // STATUS_TIMEOUT or STATUS_WAIT_0
+    // Next status task
+    threadFuncAPI nextFuncAPI;    // KeResumeThread or KeSuspendThread
+    // Don't need individual check status value, it is always STATUS_SUCCESS or
+    // STATUS_INVALID_HANDLE for wrong handle input
+    ULONG expected_suspendCount;  // Return suspend count after call
+    ULONG expected_threadCounter; // counter + addThreadCounter dynamic
+    ULONG return_threadCounter;
+    NTSTATUS return_statusWait;
+    ULONG return_suspendCount;
+} thread_test;
+
+static DWORD NTAPI KeResumeSuspendThread_sync(void* arg)
+{
+    thread_sync_counter_s* thread_data = (thread_sync_counter_s*)arg;
+    NTSTATUS status;
+    while (1) {
+        THREAD_DUO_EVENTS_WAIT(thread_data, thread_data->hEventThread, status);
+
+        thread_data->counter++;
+
+        // Let other thread to run
+        THREAD_DUO_EVENTS_SET(thread_data->hEventMain);
+    }
+    return 0;
+}
+
+static BOOL KeResumeSuspendThreadInline(const char* test_name, BOOL suspend, thread_test* thread_tests, unsigned total)
+{
+    ASSERT_HEADER;
+
+    HANDLE hEventMain, hEventThread;
+    THREAD_DUO_EVENTS_CREATE(hEventMain, hEventThread, FALSE);
+
+    thread_sync_counter_s thread_data = {
+        .terminate = FALSE,
+        .counter = 0,
+        .hEventThread = hEventThread,
+        .hEventMain = hEventMain
+    };
+
+    ULONG old_suspend_count, counter = 0;
+    NTSTATUS status;
+
+
+#if 0 // TODO: See ticket https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/issues/111 for what could be done to able test invalid arguments
+    // NOTE: __try/__except cannot be used here due to the kernel function call to KeRaiseIrqlToDpcLevel, which is not exception safe.
+    if (suspend) {
+        BOOL catch = -1;
+        __try {
+            (void)KeSuspendThread(NULL);
+            catch = 0;
+        } __except(EXCEPTION_EXECUTE_HANDLER) {
+            catch = 1;
+        }
+        GEN_CHECK(catch, 1, "catch");
+        catch = -1;
+        __try {
+            (void)KeSuspendThread((PKTHREAD)0xBEEF);
+            catch = 0;
+        } __except(EXCEPTION_EXECUTE_HANDLER) {
+            catch = 1;
+        }
+        GEN_CHECK(catch, 1, "catch");
+    }
+    else {
+        BOOL catch = -1;
+        __try {
+            (void)KeResumeThread(NULL);
+            catch = 0;
+        } __except(EXCEPTION_EXECUTE_HANDLER) {
+            catch = 1;
+        }
+        GEN_CHECK(catch, 1, "catch");
+        catch = -1;
+        __try {
+            (void)KeResumeThread((PKTHREAD)0xBEEF);
+            catch = 0;
+        } __except(EXCEPTION_EXECUTE_HANDLER) {
+            catch = 1;
+        }
+        GEN_CHECK(catch, 1, "catch");
+    }
+#endif
+
+    HANDLE hThread = CreateThread(NULL, 0, KeResumeSuspendThread_sync, (void*)&thread_data, (suspend ? CREATE_SUSPENDED : 0), NULL);
+    GEN_CHECK(hThread != NULL, TRUE, "valid handle");
+    if(!hThread) {
+        print("  ERROR: Did not create thread");
+        TEST_FAILED();
+        THREAD_DUO_EVENTS_DESTROY(hEventMain, hEventThread);
+        ASSERT_FOOTER(test_name);
+    }
+    // Since we are checking Ke functions, we need the actual thread object.
+    PETHREAD Thread;
+    status = ObReferenceObjectByHandle(hThread, &PsThreadObjectType, (PVOID*)&Thread);
+    GEN_CHECK(NT_SUCCESS(status), TRUE, "status");
+
+    // Run list of tests
+    for (unsigned i =  0; i < total; i++) {
+        thread_test* test = &thread_tests[i];
+        THREAD_DUO_EVENTS_SET(hEventThread);
+
+        // Can only check previous state begin
+        THREAD_DUO_EVENTS_WAIT_GET_STATUS(hEventMain, test->return_statusWait);
+
+        test->expected_threadCounter = counter += test->addThreadCounter;
+        test->return_threadCounter = thread_data.counter;
+        // Can only check previous state end
+
+        if (test->nextFuncAPI) {
+            old_suspend_count = test->nextFuncAPI(&Thread->Tcb);
+            test->return_suspendCount = old_suspend_count;
+        }
+    }
+
+    GEN_CHECK_ARRAY_MEMBER(thread_tests, return_threadCounter, expected_threadCounter, total, "thread_tests");
+    GEN_CHECK_ARRAY_MEMBER(thread_tests, expected_statusWait, return_statusWait, total, "thread_tests");
+    GEN_CHECK_ARRAY_MEMBER(thread_tests, expected_suspendCount, return_suspendCount, total, "thread_tests");
+
+    if (suspend) {
+        // Test for maximum suspended count limit
+        ULONG suspend_count = 0, suspend_count_old;
+        BOOL is_caught = FALSE;
+        __try {
+            do {
+                suspend_count = KeSuspendThread(&Thread->Tcb);
+                suspend_count++; // We want to get up-to-date count instead of previous count from called function
+            } while (suspend_count < 0x80);
+            is_caught = -1;
+        }
+        // We should be able to catch exception here since KeSuspendThread does throw an exception
+        __except (GetExceptionStatus(&status, EXCEPTION_EXECUTE_HANDLER)) {
+            // If an exception is caught, then don't increment the count
+            is_caught = TRUE;
+        }
+        GEN_CHECK(is_caught, TRUE, "is_caught");
+        GEN_CHECK(suspend_count, 0x7F, "suspend_count_current");
+        GEN_CHECK(status, STATUS_SUSPEND_COUNT_EXCEEDED, "status_exception");
+
+        suspend_count = KeResumeThread(&Thread->Tcb); // Require to get the updated suspend count which will start decrement from here.
+        do {
+            suspend_count_old = suspend_count;
+            suspend_count = KeResumeThread(&Thread->Tcb);
+        } while (suspend_count < suspend_count_old);
+        GEN_CHECK(suspend_count, 0, "suspend_count");
+    }
+
+    // End of test, tell the other thread to terminate
+    thread_data.terminate = TRUE;
+    THREAD_DUO_EVENTS_SET(hEventThread);
+
+    // Perform the clean up process requirement
+    THREAD_DUO_EVENTS_DESTROY_THREAD_WAIT(hThread);
+    THREAD_DUO_EVENTS_DESTROY(hEventMain, hEventThread);
+    ASSERT_FOOTER(test_name);
+}
 
 TEST_FUNC(KeAlertResumeThread)
 {
@@ -34,7 +214,28 @@ TEST_FUNC(KeQueryBasePriorityThread)
 
 TEST_FUNC(KeResumeThread)
 {
-    /* FIXME: This is a stub! implement this function! */
+    TEST_BEGIN();
+
+    thread_test thread_tests[] = {
+        // Verify if the thread is running then suspend the thread
+        { .addThreadCounter = 1, .expected_statusWait = STATUS_WAIT_0, .nextFuncAPI = KeSuspendThread, .expected_suspendCount = 0},
+        // Verify if the thread is suspended then suspend the thread again
+        { .addThreadCounter = 0, .expected_statusWait = STATUS_TIMEOUT, .nextFuncAPI = KeSuspendThread, .expected_suspendCount = 1},
+        // Verify if the thread is suspended then try resume the thread
+        { .addThreadCounter = 0, .expected_statusWait = STATUS_TIMEOUT, .nextFuncAPI = KeResumeThread, .expected_suspendCount = 2},
+        // Verify if the thread is suspended then resume the thread
+        { .addThreadCounter = 0, .expected_statusWait = STATUS_TIMEOUT, .nextFuncAPI = KeResumeThread, .expected_suspendCount = 1},
+        // Verify if the thread is resumed then try resume the thread again
+        { .addThreadCounter = 1, .expected_statusWait = STATUS_WAIT_0, .nextFuncAPI = KeResumeThread, .expected_suspendCount = 0},
+    };
+
+    char api_name_i[0x20];
+    for (unsigned i = 0; i< 10; i++) {
+        snprintf(api_name_i, ARRAY_SIZE(api_name_i), "%s[%d]", TEST_GET_API_NAME, i);
+        TEST_GET_VAR &= KeResumeSuspendThreadInline(api_name_i, FALSE, thread_tests, ARRAY_SIZE(thread_tests));
+    }
+
+    TEST_END();
 }
 
 TEST_FUNC(KeSetBasePriorityThread)
@@ -54,7 +255,34 @@ TEST_FUNC(KeSetPriorityThread)
 
 TEST_FUNC(KeSuspendThread)
 {
-    /* FIXME: This is a stub! implement this function! */
+    TEST_BEGIN();
+
+    thread_test thread_tests[] = {
+        // Verify if the thread is suspended then resume the thread
+        { .addThreadCounter = 0, .expected_statusWait = STATUS_TIMEOUT, .nextFuncAPI = KeResumeThread, .expected_suspendCount = 1},
+        // Verify if the thread is running then try resume the thread
+        { .addThreadCounter = 1, .expected_statusWait = STATUS_WAIT_0, .nextFuncAPI = KeResumeThread, .expected_suspendCount = 0},
+        // Verify if the thread is running then try resume the thread again
+        { .addThreadCounter = 1, .expected_statusWait = STATUS_WAIT_0, .nextFuncAPI = KeResumeThread, .expected_suspendCount = 0},
+        // Verify if the thread is running then suspend the thread
+        { .addThreadCounter = 1, .expected_statusWait = STATUS_WAIT_0, .nextFuncAPI = KeSuspendThread, .expected_suspendCount = 0},
+        // Verify if the thread is suspended then try suspend the thread
+        { .addThreadCounter = 0, .expected_statusWait = STATUS_TIMEOUT, .nextFuncAPI = KeSuspendThread, .expected_suspendCount = 1},
+        // Verify if the thread is suspended then try resume the thread
+        { .addThreadCounter = 0, .expected_statusWait = STATUS_TIMEOUT, .nextFuncAPI = KeResumeThread, .expected_suspendCount = 2},
+        // Verify if the thread is suspended then resume the thread
+        { .addThreadCounter = 0, .expected_statusWait = STATUS_TIMEOUT, .nextFuncAPI = KeResumeThread, .expected_suspendCount = 1},
+        // Verify if the thread is running then try resume the thread
+        { .addThreadCounter = 1, .expected_statusWait = STATUS_WAIT_0, .nextFuncAPI = KeResumeThread, .expected_suspendCount = 0},
+    };
+
+    char api_name_i[0x20];
+    for (unsigned i = 0; i< 10; i++) {
+        snprintf(api_name_i, ARRAY_SIZE(api_name_i), "%s[%d]", TEST_GET_API_NAME, i);
+        TEST_GET_VAR &= KeResumeSuspendThreadInline(api_name_i, TRUE, thread_tests, ARRAY_SIZE(thread_tests));
+    }
+
+    TEST_END();
 }
 
 TEST_FUNC(KeTestAlertThread)

--- a/src/tests/nt/NtQueueApcThread.c
+++ b/src/tests/nt/NtQueueApcThread.c
@@ -1,8 +1,0 @@
-#include <xboxkrnl/xboxkrnl.h>
-
-#include "util/output.h"
-
-TEST_FUNC(NtQueueApcThread)
-{
-    /* FIXME: This is a stub! implement this function! */
-}

--- a/src/tests/nt/NtResumeThread.c
+++ b/src/tests/nt/NtResumeThread.c
@@ -1,8 +1,0 @@
-#include <xboxkrnl/xboxkrnl.h>
-
-#include "util/output.h"
-
-TEST_FUNC(NtResumeThread)
-{
-    /* FIXME: This is a stub! implement this function! */
-}

--- a/src/tests/nt/NtSuspendThread.c
+++ b/src/tests/nt/NtSuspendThread.c
@@ -1,8 +1,0 @@
-#include <xboxkrnl/xboxkrnl.h>
-
-#include "util/output.h"
-
-TEST_FUNC(NtSuspendThread)
-{
-    /* FIXME: This is a stub! implement this function! */
-}

--- a/src/tests/nt/suite/thread.c
+++ b/src/tests/nt/suite/thread.c
@@ -1,0 +1,18 @@
+#include <xboxkrnl/xboxkrnl.h>
+
+#include "util/output.h"
+
+TEST_FUNC(NtQueueApcThread)
+{
+    /* FIXME: This is a stub! implement this function! */
+}
+
+TEST_FUNC(NtResumeThread)
+{
+    /* FIXME: This is a stub! implement this function! */
+}
+
+TEST_FUNC(NtSuspendThread)
+{
+    /* FIXME: This is a stub! implement this function! */
+}

--- a/src/tests/nt/suite/thread.c
+++ b/src/tests/nt/suite/thread.c
@@ -1,6 +1,160 @@
 #include <xboxkrnl/xboxkrnl.h>
+#include <processthreadsapi.h> // for CreateThread
+#include <stdio.h> // for snprintf
 
 #include "util/output.h"
+#include "util/misc.h"
+#include "util/thread.h"
+#include "util/exception.h"
+#include "assertions/defines.h"
+
+// TODO: Add below into nxdk's xboxkrnl/ntstatus.h file
+#define STATUS_SUSPEND_COUNT_EXCEEDED 0xC000004A
+
+typedef struct {
+    BOOL terminate;
+    ULONG counter;
+    HANDLE hEventThread;
+    HANDLE hEventMain;
+} thread_sync_counter_s;
+
+typedef NTSTATUS (NTAPI *threadFuncAPI)(HANDLE, PULONG);
+
+typedef struct _thread_test {
+    // Previous status check
+    BOOL addThreadCounter;        // 0 or 1
+    NTSTATUS expected_statusWait; // STATUS_TIMEOUT or STATUS_WAIT_0
+    // Next status task
+    threadFuncAPI nextFuncAPI;    // NtResumeThread or NtSuspendThread
+    // Don't need individual check status value, it is always STATUS_SUCCESS or
+    // STATUS_INVALID_HANDLE for wrong handle input
+    ULONG expected_suspendCount;  // Return suspend count after call
+    ULONG expected_threadCounter; // counter + addThreadCounter dynamic
+    ULONG return_threadCounter;
+    DWORD return_statusWait;
+    ULONG return_suspendCount;
+} thread_test;
+
+static DWORD NTAPI NtResumeSuspendThread_sync(void* arg)
+{
+    thread_sync_counter_s* thread_data = (thread_sync_counter_s*)arg;
+    NTSTATUS status;
+    while (1) {
+        THREAD_DUO_EVENTS_WAIT(thread_data, thread_data->hEventThread, status);
+
+        thread_data->counter++;
+
+        // Let other thread to run
+        THREAD_DUO_EVENTS_SET(thread_data->hEventMain);
+    }
+    return 0;
+}
+
+static BOOL NtResumeSuspendThreadInline(const char* test_name, BOOL suspend, thread_test* thread_tests, unsigned total)
+{
+    ASSERT_HEADER;
+
+    HANDLE hEventMain, hEventThread;
+    THREAD_DUO_EVENTS_CREATE(hEventMain, hEventThread, FALSE);
+
+    thread_sync_counter_s thread_data = {
+        .terminate = FALSE,
+        .counter = 0,
+        .hEventThread = hEventThread,
+        .hEventMain = hEventMain
+    };
+
+    ULONG old_suspend_count, counter = 0;
+    NTSTATUS status, status_try;
+
+    if (suspend) {
+        status = NtSuspendThread(NULL, NULL);
+        GEN_CHECK(status, STATUS_INVALID_HANDLE, "status");
+        status = NtSuspendThread((HANDLE)0xDEADBEEF, NULL);
+        GEN_CHECK(status, STATUS_INVALID_HANDLE, "status");
+    }
+    else {
+        status = NtResumeThread(NULL, NULL);
+        GEN_CHECK(status, STATUS_INVALID_HANDLE, "status");
+        status = NtResumeThread((HANDLE)0xDEADBEEF, NULL);
+        GEN_CHECK(status, STATUS_INVALID_HANDLE, "status");
+    }
+
+    HANDLE hThread = CreateThread(NULL, 0, NtResumeSuspendThread_sync, (void*)&thread_data, (suspend ? CREATE_SUSPENDED : 0), NULL);
+    GEN_CHECK(hThread != NULL, TRUE, "valid handle");
+    if(!hThread) {
+        print("  ERROR: Did not create thread");
+        TEST_FAILED();
+        THREAD_DUO_EVENTS_DESTROY(hEventMain, hEventThread);
+        ASSERT_FOOTER(test_name);
+    }
+
+    // Run list of tests
+    for (unsigned i =  0; i < total; i++) {
+        thread_test* test = &thread_tests[i];
+        THREAD_DUO_EVENTS_SET(hEventThread);
+
+        // Can only check previous state begin
+        THREAD_DUO_EVENTS_WAIT_GET_STATUS(hEventMain, test->return_statusWait);
+
+        test->expected_threadCounter = counter += test->addThreadCounter;
+        test->return_threadCounter = thread_data.counter;
+        // Can only check previous state end
+
+        if (test->nextFuncAPI) {
+            status = test->nextFuncAPI(hThread, &old_suspend_count);
+            test->return_suspendCount = old_suspend_count;
+            GEN_CHECK(status, STATUS_SUCCESS, "status");
+        }
+    }
+
+    GEN_CHECK_ARRAY_MEMBER(thread_tests, return_threadCounter, expected_threadCounter, total, "thread_tests");
+    GEN_CHECK_ARRAY_MEMBER(thread_tests, expected_statusWait, return_statusWait, total, "thread_tests");
+    GEN_CHECK_ARRAY_MEMBER(thread_tests, expected_suspendCount, return_suspendCount, total, "thread_tests");
+
+    if (suspend) {
+        // Test for maximum suspended count limit
+        ULONG suspend_count = 0, suspend_count_old;
+        BOOL is_caught = FALSE;
+        status = STATUS_SUCCESS;
+        __try {
+            do {
+                status_try = NtSuspendThread(hThread, &suspend_count);
+                if (!NT_SUCCESS(status_try)) {
+                    // If a failed status is received, then don't increment the count
+                    break;
+                }
+                suspend_count++; // We want to get up-to-date count instead of previous count from called function
+            } while (suspend_count < 0x80);
+            is_caught = -1;
+        }
+        // We should not be able to catch exception here since NtSuspendThread does catch KeSuspendThread's thrown exception
+        __except (GetExceptionStatus(&status, EXCEPTION_EXECUTE_HANDLER)) {
+            // If an exception is caught, then don't increment the count
+            is_caught = TRUE;
+        }
+        GEN_CHECK(is_caught, -1, "is_caught");
+        GEN_CHECK(suspend_count, 0x7F, "suspend_count_current");
+        GEN_CHECK(status_try, STATUS_SUSPEND_COUNT_EXCEEDED, "status");
+        GEN_CHECK(status, STATUS_SUCCESS, "status_exception");
+
+        (void)NtResumeThread(hThread, &suspend_count); // Require to get the updated suspend count which will start decrement from here.
+        do {
+            suspend_count_old = suspend_count;
+            (void)NtResumeThread(hThread, &suspend_count);
+        } while (suspend_count < suspend_count_old);
+        GEN_CHECK(suspend_count, 0, "suspend_count");
+    }
+
+    // End of test, tell the other thread to terminate
+    thread_data.terminate = TRUE;
+    THREAD_DUO_EVENTS_SET(hEventThread);
+
+    // Perform the clean up process requirement
+    THREAD_DUO_EVENTS_DESTROY_THREAD_WAIT(hThread);
+    THREAD_DUO_EVENTS_DESTROY(hEventMain, hEventThread);
+    ASSERT_FOOTER(test_name);
+}
 
 TEST_FUNC(NtQueueApcThread)
 {
@@ -9,10 +163,58 @@ TEST_FUNC(NtQueueApcThread)
 
 TEST_FUNC(NtResumeThread)
 {
-    /* FIXME: This is a stub! implement this function! */
+    TEST_BEGIN();
+
+    thread_test thread_tests[] = {
+        // Verify if the thread is running then suspend the thread
+        { .addThreadCounter = 1, .expected_statusWait = STATUS_WAIT_0, .nextFuncAPI = NtSuspendThread, .expected_suspendCount = 0},
+        // Verify if the thread is suspended then suspend the thread again
+        { .addThreadCounter = 0, .expected_statusWait = STATUS_TIMEOUT, .nextFuncAPI = NtSuspendThread, .expected_suspendCount = 1},
+        // Verify if the thread is suspended then try resume the thread
+        { .addThreadCounter = 0, .expected_statusWait = STATUS_TIMEOUT, .nextFuncAPI = NtResumeThread, .expected_suspendCount = 2},
+        // Verify if the thread is suspended then resume the thread
+        { .addThreadCounter = 0, .expected_statusWait = STATUS_TIMEOUT, .nextFuncAPI = NtResumeThread, .expected_suspendCount = 1},
+        // Verify if the thread is resumed then try resume the thread again
+        { .addThreadCounter = 1, .expected_statusWait = STATUS_WAIT_0, .nextFuncAPI = NtResumeThread, .expected_suspendCount = 0},
+    };
+
+    char api_name_i[0x20];
+    for (unsigned i = 0; i< 10; i++) {
+        snprintf(api_name_i, ARRAY_SIZE(api_name_i), "%s[%d]", TEST_GET_API_NAME, i);
+        TEST_GET_VAR &= NtResumeSuspendThreadInline(api_name_i, FALSE, thread_tests, ARRAY_SIZE(thread_tests));
+    }
+
+    TEST_END();
 }
 
 TEST_FUNC(NtSuspendThread)
 {
-    /* FIXME: This is a stub! implement this function! */
+    TEST_BEGIN();
+
+    thread_test thread_tests[] = {
+        // Verify if the thread is suspended then resume the thread
+        { .addThreadCounter = 0, .expected_statusWait = STATUS_TIMEOUT, .nextFuncAPI = NtResumeThread, .expected_suspendCount = 1},
+        // Verify if the thread is running then try resume the thread
+        { .addThreadCounter = 1, .expected_statusWait = STATUS_WAIT_0, .nextFuncAPI = NtResumeThread, .expected_suspendCount = 0},
+        // Verify if the thread is running then try resume the thread again
+        { .addThreadCounter = 1, .expected_statusWait = STATUS_WAIT_0, .nextFuncAPI = NtResumeThread, .expected_suspendCount = 0},
+        // Verify if the thread is running then suspend the thread
+        { .addThreadCounter = 1, .expected_statusWait = STATUS_WAIT_0, .nextFuncAPI = NtSuspendThread, .expected_suspendCount = 0},
+        // Verify if the thread is suspended then try suspend the thread
+        { .addThreadCounter = 0, .expected_statusWait = STATUS_TIMEOUT, .nextFuncAPI = NtSuspendThread, .expected_suspendCount = 1},
+        // Verify if the thread is suspended then try resume the thread
+        { .addThreadCounter = 0, .expected_statusWait = STATUS_TIMEOUT, .nextFuncAPI = NtResumeThread, .expected_suspendCount = 2},
+        // Verify if the thread is suspended then resume the thread
+        { .addThreadCounter = 0, .expected_statusWait = STATUS_TIMEOUT, .nextFuncAPI = NtResumeThread, .expected_suspendCount = 1},
+        // Verify if the thread is running then try resume the thread
+        { .addThreadCounter = 1, .expected_statusWait = STATUS_WAIT_0, .nextFuncAPI = NtResumeThread, .expected_suspendCount = 0},
+    };
+
+    char api_name_i[0x20];
+    for (unsigned i = 0; i< 10; i++) {
+        snprintf(api_name_i, ARRAY_SIZE(api_name_i), "%s[%d]", TEST_GET_API_NAME, i);
+        TEST_GET_VAR &= NtResumeSuspendThreadInline(api_name_i, TRUE, thread_tests, ARRAY_SIZE(thread_tests));
+    }
+
+    TEST_END();
 }

--- a/src/util/exception.c
+++ b/src/util/exception.c
@@ -1,0 +1,6 @@
+#include "exception.h"
+
+BOOL GetExceptionStatusEx(NTSTATUS exception_code, NTSTATUS *status, BOOL ret) {
+    *status = exception_code;
+    return ret;
+}

--- a/src/util/exception.h
+++ b/src/util/exception.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <excpt.h>
+
+BOOL GetExceptionStatusEx(NTSTATUS exception_code, NTSTATUS *status, BOOL ret);
+
+#define GetExceptionStatus(status, ret) GetExceptionStatusEx(GetExceptionCode(), status, ret)

--- a/src/util/output.h
+++ b/src/util/output.h
@@ -7,13 +7,16 @@ void print_test_header(int, const char*);
 void print_test_footer(int, const char*, BOOL);
 
 #define TEST_FUNC(name) void test_ ## name(int api_num, const char* api_name)
+#define TEST_GET_VAR test_passed
+#define TEST_GET_API_N api_num
+#define TEST_GET_API_NAME api_name
 #define TEST_BEGIN() print_test_header(api_num, api_name); \
-    BOOL test_passed = 1
+    BOOL TEST_GET_VAR = 1
 #define TEST_END() print_test_footer(api_num, api_name, test_passed)
 #define TEST_UNIMPLEMENTED()
-#define TEST_FAILED() test_passed = 0
-#define TEST_IS_FAILED (!test_passed)
-#define TEST_IS_SUCCESS (test_passed)
+#define TEST_FAILED() TEST_GET_VAR = 0
+#define TEST_IS_FAILED (!TEST_GET_VAR)
+#define TEST_IS_SUCCESS (TEST_GET_VAR)
 
 // Real hardware can only display one screen of text at a time. Create an output
 // logfile to contain information for all tests.

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <xboxkrnl/ntstatus.h> // for STATUS_ prefix
+
+static LARGE_INTEGER infinite = { .QuadPart = ((LONGLONG)INFINITE) * -10000 };
+static LARGE_INTEGER thread_duo_wait_delay1 = { .QuadPart = ((LONGLONG)1) * -10000 };
+static LARGE_INTEGER thread_duo_wait_delay10 = { .QuadPart = ((LONGLONG)10) * -10000 };
+
+// Create two events for two threads switching
+#define THREAD_DUO_EVENTS_CREATE(Primary, Secondary, InitialStatePrimary) \
+    (void)NtCreateEvent(&Primary, NULL, SynchronizationEvent, InitialStatePrimary); \
+    (void)NtCreateEvent(&Secondary, NULL, SynchronizationEvent, FALSE)
+// Close event handles for two threads switching
+#define THREAD_DUO_EVENTS_DESTROY(Primary, Secondary) \
+    (void)NtClose(Secondary); \
+    (void)NtClose(Primary)
+// Wait until thread is terminated
+#define THREAD_DUO_EVENTS_DESTROY_THREAD_WAIT(hThread) \
+    (void)NtWaitForSingleObject(hThread, FALSE, &infinite); \
+    (void)NtClose(hThread)
+// Wait for event to trigger
+#define THREAD_DUO_EVENTS_WAIT(data, hEvent, status) \
+    do { \
+        status = NtWaitForSingleObject(hEvent, FALSE, &thread_duo_wait_delay10); \
+        if (status == STATUS_WAIT_0) { \
+            break; \
+        } \
+        if (data->terminate) { \
+            return 0; \
+        } \
+        if (status != STATUS_TIMEOUT) { \
+            print("  %s thread terminated with 0x%08X", __func__ , status); \
+            data->terminate = TRUE; \
+            return 1; \
+        } \
+        (void)NtYieldExecution(); \
+    } while (status == STATUS_TIMEOUT)
+// Wait for event to trigger with status return only
+#define THREAD_DUO_EVENTS_WAIT_GET_STATUS(hEvent, status) \
+        status = NtWaitForSingleObject(hEvent, FALSE, &thread_duo_wait_delay1)
+// Notify other thread to run
+#define THREAD_DUO_EVENTS_SET(Notify) \
+    (void)NtSetEvent(Notify, NULL); \
+    /* Allow the other thread that may in need to process */ \
+    (void)NtYieldExecution()


### PR DESCRIPTION
The following kernel APIs are implemented for the tests:
- KeResumeThread
- KeSuspendThread
- NtResumeThread
- NtSuspendThread

The code has been optimized to be able to reuse the same purpose across Nt and Ke thread tests. However, `THREAD_DUO_EVENTS_` prefix macro could be used for other APIs if needed.