### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout nxdk
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: XboxDev/nxdk
           submodules: recursive
@@ -28,7 +28,7 @@ jobs:
         id: xkts
         run: echo "dir=projects/xbox_kernel_test_suite" >> $GITHUB_OUTPUT
       - name: Checkout xbox_kernel_test_suite
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           path: ${{ steps.xkts.outputs.dir }}
       - name: Install dependencies
@@ -47,10 +47,10 @@ jobs:
           echo "name=$file" >> $GITHUB_OUTPUT
           echo "path=${{ steps.xkts.outputs.dir }}/bin/$file" >> $GITHUB_OUTPUT
           echo "tag=$(date +'%Y%m%d%H%M%S')-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
-          name: ${{ steps.parameters.outputs.name }}
           path: ${{ steps.parameters.outputs.path }}
+          archive: false
           if-no-files-found: error
       - name: Create release
         if: |


### PR DESCRIPTION
Upgraded the `checkout` action from v5 to v7 and the `upload-artifact` action from v4 to v7.

Additionally, the `upload-artifact` action recently introduced the ability to upload unzipped files. Thanks to @Margen67 for bringing this to my attention.