### PR TITLE
General Update and Prepare Feature Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
-XBE_TITLE=kernel\ test\ suite
-recursivewildcard=$(foreach d,$(wildcard $(1:=/*)),$(call recursivewildcard,$d,$2) $(filter $(subst *,%,$2),$d))
-SRCS = $(call recursivewildcard,src,*.c)
+XBE_TITLE := kernel\ test\ suite
+
+recursivewildcard = $(foreach d,$(wildcard $(1:=/*)),$(call recursivewildcard,$d,$2) $(filter $(subst *,%,$2),$d))
+SRCS := $(call recursivewildcard,src,*.c)
 SRCS := $(SRCS) $(call recursivewildcard,src,*.cpp)
-GIT_VERSION = "$(shell git describe --always --tags --first-parent --dirty)"
-NXDK_CFLAGS = -I$(CURDIR)/src -DGIT_VERSION=\"$(GIT_VERSION)\"
-NXDK_CXXFLAGS = -I$(CURDIR)/src -DGIT_VERSION=\"$(GIT_VERSION)\"
-NXDK_CXX = y
+
+GIT_VERSION := "$(shell git describe --always --tags --first-parent --dirty)"
+
+NXDK_CFLAGS := -I$(CURDIR)/src -DGIT_VERSION=\"$(GIT_VERSION)\"
+NXDK_CXXFLAGS := -I$(CURDIR)/src -DGIT_VERSION=\"$(GIT_VERSION)\"
+NXDK_CXX := y
+
 include $(NXDK_DIR)/Makefile

--- a/src/assertions/common.h
+++ b/src/assertions/common.h
@@ -10,7 +10,7 @@
     api_name, \
     line_number \
 ) \
-    if(status != expected_status) { \
+    if (status != expected_status) { \
         print( \
             "  ERROR(line %d): Expected return status of function '%s' = 0x%x, got = 0x%x", \
             line_number, \

--- a/src/assertions/defines.h
+++ b/src/assertions/defines.h
@@ -22,17 +22,17 @@
     }
 #define GEN_CHECK(check_var, expected_var, varname) GEN_CHECK_EX(check_var, expected_var, varname, __LINE__)
 
-#define GEN_CHECK_RANGE_EX(check_var, expected_var, size, varname, func_line) \
-    if((check_var) < (expected_var) || (check_var) > (expected_var) + (size)) { \
+#define GEN_CHECK_RANGE_EX(check_var, expected_var, length, varname, func_line) \
+    if((check_var) < (expected_var) || (check_var) > (expected_var) + (length)) { \
         print( \
             ((sizeof(check_var) > 4) ? \
             "  ERROR(line %d): Expected range %s = 0x%x-0x%llx, Got = 0x%llx" : \
             "  ERROR(line %d): Expected range %s = 0x%x-0x%x, Got = 0x%x") \
-            , func_line, varname, (expected_var), (expected_var) + (size), (check_var) \
+            , func_line, varname, (expected_var), (expected_var) + (length), (check_var) \
         ); \
         TEST_FAILED(); \
     }
-#define GEN_CHECK_RANGE(check_var, expected_var, size, varname) GEN_CHECK_RANGE_EX(check_var, expected_var, size, varname, __LINE__)
+#define GEN_CHECK_RANGE(check_var, expected_var, length, varname) GEN_CHECK_RANGE_EX(check_var, expected_var, length, varname, __LINE__)
 
 #define GEN_CHECK_ARRAY_EX(check_var, expected_var, size, varname, func_line) \
     for (unsigned i = 0; i < (size); i++) { \

--- a/src/assertions/defines.h
+++ b/src/assertions/defines.h
@@ -5,13 +5,13 @@
 #define ASSERT_HEADER BOOL test_passed = 1;
 
 #define ASSERT_FOOTER(test_name) \
-    if(!test_passed) { \
+    if (!test_passed) { \
         print("  Test '%s' FAILED", test_name); \
     } \
     return test_passed;
 
 #define GEN_CHECK_EX(check_var, expected_var, varname, func_line) \
-    if((check_var) != (expected_var)) { \
+    if ((check_var) != (expected_var)) { \
         print( \
             ((sizeof(check_var) > 4) ? \
             "  ERROR(line %d): Expected %s = 0x%llx, Got = 0x%llx" : \
@@ -23,7 +23,7 @@
 #define GEN_CHECK(check_var, expected_var, varname) GEN_CHECK_EX(check_var, expected_var, varname, __LINE__)
 
 #define GEN_CHECK_RANGE_EX(check_var, expected_var, length, varname, func_line) \
-    if((check_var) < (expected_var) || (check_var) > (expected_var) + (length)) { \
+    if ((check_var) < (expected_var) || (check_var) > (expected_var) + (length)) { \
         print( \
             ((sizeof(check_var) > 4) ? \
             "  ERROR(line %d): Expected range %s = 0x%x-0x%llx, Got = 0x%llx" : \

--- a/src/assertions/defines.h
+++ b/src/assertions/defines.h
@@ -11,37 +11,37 @@
     return test_passed;
 
 #define GEN_CHECK_EX(check_var, expected_var, varname, func_line) \
-    if(check_var != expected_var) { \
+    if((check_var) != (expected_var)) { \
         print( \
             ((sizeof(check_var) > 4) ? \
             "  ERROR(line %d): Expected %s = 0x%llx, Got = 0x%llx" : \
             "  ERROR(line %d): Expected %s = 0x%x, Got = 0x%x") \
-            , func_line, varname, expected_var, check_var \
+            , func_line, varname, (expected_var), (check_var) \
         ); \
         TEST_FAILED(); \
     }
 #define GEN_CHECK(check_var, expected_var, varname) GEN_CHECK_EX(check_var, expected_var, varname, __LINE__)
 
 #define GEN_CHECK_RANGE_EX(check_var, expected_var, size, varname, func_line) \
-    if(check_var < expected_var || check_var > expected_var + size) { \
+    if((check_var) < (expected_var) || (check_var) > (expected_var) + (size)) { \
         print( \
             ((sizeof(check_var) > 4) ? \
             "  ERROR(line %d): Expected range %s = 0x%x-0x%llx, Got = 0x%llx" : \
             "  ERROR(line %d): Expected range %s = 0x%x-0x%x, Got = 0x%x") \
-            , func_line, varname, expected_var, expected_var + size, check_var \
+            , func_line, varname, (expected_var), (expected_var) + (size), (check_var) \
         ); \
         TEST_FAILED(); \
     }
 #define GEN_CHECK_RANGE(check_var, expected_var, size, varname) GEN_CHECK_RANGE_EX(check_var, expected_var, size, varname, __LINE__)
 
 #define GEN_CHECK_ARRAY_EX(check_var, expected_var, size, varname, func_line) \
-    for (unsigned i = 0; i < size; i++) { \
-        if (check_var[i] != expected_var[i]) { \
+    for (unsigned i = 0; i < (size); i++) { \
+        if ((check_var)[i] != (expected_var)[i]) { \
             print( \
-                ((sizeof(check_var[i]) > 4) ? \
+                ((sizeof((check_var)[i]) > 4) ? \
                 "  ERROR(line %d): Expected array %s[%u] = 0x%llx, Got = 0x%llx" : \
                 "  ERROR(line %d): Expected array %s[%u] = 0x%x, Got = 0x%x") \
-                , func_line, varname, i, expected_var[i], check_var[i] \
+                , func_line, varname, i, (expected_var)[i], (check_var)[i] \
             ); \
             TEST_FAILED(); \
         } \
@@ -49,13 +49,13 @@
 #define GEN_CHECK_ARRAY(check_var, expected_var, size, varname) GEN_CHECK_ARRAY_EX(check_var, expected_var, size, varname, __LINE__)
 
 #define GEN_CHECK_ARRAY_MEMBER_EX(var, m_check, m_expected, size, varname, func_line) \
-    for (unsigned i = 0; i < size; i++) { \
-        if (var[i].m_check != var[i].m_expected) { \
+    for (unsigned i = 0; i < (size); i++) { \
+        if ((var)[i].m_check != (var)[i].m_expected) { \
             print( \
-                ((sizeof(var[i].m_check) > 4) ? \
+                ((sizeof((var)[i].m_check) > 4) ? \
                 "  ERROR(line %d): Expected array %s[%u].%s = 0x%llx, Got %s[%u].%s = 0x%llx" : \
                 "  ERROR(line %d): Expected array %s[%u].%s = 0x%x, Got %s[%u].%s = 0x%x") \
-                , func_line, varname, i, #m_expected, var[i].m_expected, varname, i, #m_check, var[i].m_check \
+                , func_line, varname, i, #m_expected, (var)[i].m_expected, varname, i, #m_check, (var)[i].m_check \
             ); \
             TEST_FAILED(); \
         } \

--- a/src/assertions/rtl.c
+++ b/src/assertions/rtl.c
@@ -17,13 +17,13 @@ BOOL assert_ansi_string_ex(
     GEN_CHECK_EX(string->Length, expected_Length, "Length", line_number);
     GEN_CHECK_EX(string->MaximumLength, expected_MaximumLength, "MaximumLength", line_number);
 
-    if(expected_Buffer == NULL) {
+    if (expected_Buffer == NULL) {
         GEN_CHECK_EX(string->Buffer, NULL, "Buffer is NULL", line_number);
     }
     else {
         int result = memcmp(string->Buffer, expected_Buffer, expected_Length);
         GEN_CHECK_EX(result, 0, "memcmp result of Buffer", line_number);
-        if(result) {
+        if (result) {
             print("  Buffer = %s, expected_Buffer = %s", string->Buffer, expected_Buffer);
         }
     }
@@ -44,7 +44,7 @@ BOOL assert_unicode_string_ex(
     GEN_CHECK_EX(string->Length, expected_Length, "Length", line_number);
     GEN_CHECK_EX(string->MaximumLength, expected_MaximumLength, "MaximumLength", line_number);
 
-    if(expected_Buffer == NULL) {
+    if (expected_Buffer == NULL) {
         GEN_CHECK_EX(string->Buffer, NULL, "Buffer is null", line_number);
     }
     else {

--- a/src/tests/av/AvSetSavedDataAddress.c
+++ b/src/tests/av/AvSetSavedDataAddress.c
@@ -8,7 +8,7 @@ TEST_FUNC(AvSetSavedDataAddress)
     TEST_BEGIN();
 
     AvSetSavedDataAddress((void*) NULL);
-    test_passed = AvGetSavedDataAddress()==(void*) NULL ? 1 : 0;
+    TEST_GET_VAR = AvGetSavedDataAddress()==(void*) NULL ? 1 : 0;
 
     TEST_END();
 }

--- a/src/tests/ex/ExAcquireReadWriteLockExclusive.c
+++ b/src/tests/ex/ExAcquireReadWriteLockExclusive.c
@@ -89,7 +89,7 @@ TEST_FUNC(ExAcquireReadWriteLockExclusive)
         return;
     }
 
-    test_passed = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 1);
+    TEST_GET_VAR = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 1);
     if (TEST_IS_FAILED) {
         print("  ERROR: LockCount did not equal 1\n");
         TEST_FAILED();
@@ -104,7 +104,7 @@ TEST_FUNC(ExAcquireReadWriteLockExclusive)
         print("  ERROR: The second thread was not supposed to write before the lock is released on the first thread.");
     }
     ExReleaseReadWriteLock(&ReadWriteLock);
-    test_passed = timed_poll_for_value(&control.thread2_status, 2);
+    TEST_GET_VAR = timed_poll_for_value(&control.thread2_status, 2);
     if (TEST_IS_FAILED) {
         print("  ERROR: thread2_status did not equal 2 before timing out.\n");
         TEST_FAILED();

--- a/src/tests/ex/ExAcquireReadWriteLockExclusive.c
+++ b/src/tests/ex/ExAcquireReadWriteLockExclusive.c
@@ -71,7 +71,6 @@ TEST_FUNC(ExAcquireReadWriteLockExclusive)
     // Avoid spinning forever in the loop below.
     if (TEST_IS_FAILED) {
         TEST_END();
-        return;
     }
     ExReleaseReadWriteLock(&ReadWriteLock);
 
@@ -86,7 +85,6 @@ TEST_FUNC(ExAcquireReadWriteLockExclusive)
         print("  ERROR: did not create thread");
         TEST_FAILED();
         TEST_END();
-        return;
     }
 
     TEST_GET_VAR = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 1);
@@ -94,7 +92,6 @@ TEST_FUNC(ExAcquireReadWriteLockExclusive)
         print("  ERROR: LockCount did not equal 1\n");
         TEST_FAILED();
         TEST_END();
-        return;
     }
     // Second thread attempted to acquire the exclusive lock, incrementing WritersWaitingCount
     assert_ERWLOCK_equals(&ReadWriteLock, 1, 1, 0, 0);

--- a/src/tests/ex/ExAcquireReadWriteLockExclusive.c
+++ b/src/tests/ex/ExAcquireReadWriteLockExclusive.c
@@ -39,8 +39,8 @@ static void increment_thread3_status(control_struct* control, const char* callin
 
 static BOOL timed_poll_for_value(ULONG* poll_var, ULONG wait_value)
 {
-    for(BYTE i = 0; i < 10; i++) {
-        if(*poll_var == wait_value) {
+    for (BYTE i = 0; i < 10; i++) {
+        if (*poll_var == wait_value) {
             return 1;
         }
         Sleep(10);
@@ -90,7 +90,7 @@ TEST_FUNC(ExAcquireReadWriteLockExclusive)
     }
 
     test_passed = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 1);
-    if(TEST_IS_FAILED) {
+    if (TEST_IS_FAILED) {
         print("  ERROR: LockCount did not equal 1\n");
         TEST_FAILED();
         TEST_END();
@@ -99,13 +99,13 @@ TEST_FUNC(ExAcquireReadWriteLockExclusive)
     // Second thread attempted to acquire the exclusive lock, incrementing WritersWaitingCount
     assert_ERWLOCK_equals(&ReadWriteLock, 1, 1, 0, 0);
 
-    if(control.thread2_status == 1) {
+    if (control.thread2_status == 1) {
         TEST_FAILED();
         print("  ERROR: The second thread was not supposed to write before the lock is released on the first thread.");
     }
     ExReleaseReadWriteLock(&ReadWriteLock);
     test_passed = timed_poll_for_value(&control.thread2_status, 2);
-    if(TEST_IS_FAILED) {
+    if (TEST_IS_FAILED) {
         print("  ERROR: thread2_status did not equal 2 before timing out.\n");
         TEST_FAILED();
     }

--- a/src/tests/ex/ExAcquireReadWriteLockShared.c
+++ b/src/tests/ex/ExAcquireReadWriteLockShared.c
@@ -33,8 +33,8 @@ static void increment_thread3_status(control_struct* control, const char* callin
 
 static BOOL timed_poll_for_value(ULONG* poll_var, ULONG wait_value)
 {
-    for(BYTE i = 0; i < 10; i++) {
-        if(*poll_var == wait_value) {
+    for (BYTE i = 0; i < 10; i++) {
+        if (*poll_var == wait_value) {
             return 1;
         }
         Sleep(10);
@@ -49,7 +49,7 @@ static void NTAPI ExAcquireReadWriteLockShared_thread2(void* arg)
 
     // Test case where LockCount != 0, and ReaderEntryCount == 0, which should cause this thread to wait.
     BOOL value_found = timed_poll_for_value(&control->thread2_cmd, 1);
-    if(!value_found) {
+    if (!value_found) {
         print("  ERROR: %s failed waiting for thread2_cmd == 1", api_name);
         PsTerminateSystemThread(STATUS_TIMEOUT);
     }
@@ -61,7 +61,7 @@ static void NTAPI ExAcquireReadWriteLockShared_thread2(void* arg)
 
     // Test case where LockCount != 0, ReaderEntryCount != 0, and WritersWaitingCount == 0. Should grab lock fine.
     value_found = timed_poll_for_value(&control->thread2_cmd, 2);
-    if(!value_found) {
+    if (!value_found) {
         print("  ERROR: %s failed waiting for thread2_cmd == 2", api_name);
         PsTerminateSystemThread(STATUS_TIMEOUT);
     }
@@ -69,7 +69,7 @@ static void NTAPI ExAcquireReadWriteLockShared_thread2(void* arg)
     increment_thread2_status(control, api_name);
 
     value_found = timed_poll_for_value(&control->thread2_cmd, 3);
-    if(!value_found) {
+    if (!value_found) {
         print("  ERROR: %s failed waiting for thread2_cmd == 3", api_name);
         PsTerminateSystemThread(STATUS_TIMEOUT);
     }
@@ -79,7 +79,7 @@ static void NTAPI ExAcquireReadWriteLockShared_thread2(void* arg)
 
     // Test case where LockCount != 0, ReaderEntryCount != 0, and WritersWaitingCount != 0. Should wait for exclusive thread to release.
     value_found = timed_poll_for_value(&control->thread2_cmd, 4);
-    if(!value_found) {
+    if (!value_found) {
         print("  ERROR: %s failed waiting for thread2_cmd == 4", api_name);
         PsTerminateSystemThread(STATUS_TIMEOUT);
     }
@@ -113,7 +113,7 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     // Acquire shared lock on empty lock
     assert_ERWLOCK_equals(&ReadWriteLock, 0, 0, 0, 1);
     // Avoid spinning forever in the loop below.
-    if(TEST_IS_FAILED) {
+    if (TEST_IS_FAILED) {
         TEST_END();
         return;
     }
@@ -124,7 +124,7 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     control_struct control = {&ReadWriteLock, 0, 0, 0, 0};
     HANDLE handle;
     NTSTATUS result = PsCreateSystemThread(&handle, NULL, ExAcquireReadWriteLockShared_thread2, (void*)&control, 0);
-    if(result != STATUS_SUCCESS) {
+    if (result != STATUS_SUCCESS) {
         print("  ERROR: Did not create thread2");
         TEST_FAILED();
         TEST_END();
@@ -135,14 +135,14 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     increment_thread2_cmd(&control, api_name);
 
     test_passed = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 1);
-    if(TEST_IS_FAILED) {
+    if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for LockCount == 1", api_name);
         TEST_END();
         return;
     }
     // Second thread attempted to acquire the exclusive lock, incrementing ReadersWaitingCount and waiting
     assert_ERWLOCK_equals(&ReadWriteLock, 1, 0, 1, 0);
-    if(control.thread2_status == 1) {
+    if (control.thread2_status == 1) {
         TEST_FAILED();
         print("  ERROR: The second thread was not supposed to write before the lock is released on the first thread.");
         TEST_END();
@@ -151,7 +151,7 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
 
     ExReleaseReadWriteLock(&ReadWriteLock);
     test_passed = timed_poll_for_value(&control.thread2_status, 2);
-    if(TEST_IS_FAILED) {
+    if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for thread2_status == 2", api_name);
         TEST_END();
         return;
@@ -162,7 +162,7 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     increment_thread2_cmd(&control, api_name);
 
     test_passed = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 1);
-    if(TEST_IS_FAILED) {
+    if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for LockCount == 1", api_name);
         TEST_END();
         return;
@@ -170,7 +170,7 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     // Second thread attempted to acquire the shared lock, incrementing ReaderEntryCount and getting the lock
     assert_ERWLOCK_equals(&ReadWriteLock, 1, 0, 0, 2);
     Sleep(10);
-    if(control.thread2_status != 3) {
+    if (control.thread2_status != 3) {
         TEST_FAILED();
         print("  ERROR: The second thread was supposed to obtain the shared lock and update thread2_status.");
         TEST_END();
@@ -180,7 +180,7 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     increment_thread2_cmd(&control, api_name);
     ExReleaseReadWriteLock(&ReadWriteLock);
     test_passed = timed_poll_for_value(&control.thread2_status, 4);
-    if(TEST_IS_FAILED) {
+    if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for thread2_status == 4", api_name);
         TEST_END();
         return;
@@ -191,7 +191,7 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     increment_thread2_cmd(&control, api_name);
 
     test_passed = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 1);
-    if(TEST_IS_FAILED) {
+    if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for LockCount == 1", api_name);
         TEST_END();
         return;
@@ -199,21 +199,21 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
 
     HANDLE handle_thread3;
     result = PsCreateSystemThread(&handle_thread3, NULL, ExAcquireReadWriteLockShared_thread3, (void*)&control, 0);
-    if(result != STATUS_SUCCESS) {
+    if (result != STATUS_SUCCESS) {
         TEST_FAILED();
         TEST_END();
         return;
     }
 
     test_passed = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 2);
-    if(TEST_IS_FAILED) {
+    if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for LockCount == 2", api_name);
         TEST_END();
         return;
     }
     // Third thread attempted to acquire the shared lock but there is already another exclusive request in flight.
     assert_ERWLOCK_equals(&ReadWriteLock, 2, 1, 1, 1);
-    if(control.thread3_status == 1) {
+    if (control.thread3_status == 1) {
         TEST_FAILED();
         TEST_END();
         return;
@@ -221,9 +221,9 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     ExReleaseReadWriteLock(&ReadWriteLock);
 
     print("  Waiting for thread statuses to be at their final value.");
-    for(BYTE i = 0; i < 10; i++) {
+    for (BYTE i = 0; i < 10; i++) {
         TEST_FAILED(); // TODO: Why force fail here?
-        if( (control.thread2_status == 6) && (control.thread3_status == 2) ) {
+        if ((control.thread2_status == 6) && (control.thread3_status == 2)) {
             test_passed = 1; // TODO: test_passed should not be used here.
             break;
         }

--- a/src/tests/ex/ExAcquireReadWriteLockShared.c
+++ b/src/tests/ex/ExAcquireReadWriteLockShared.c
@@ -134,7 +134,7 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     ExAcquireReadWriteLockExclusive(&ReadWriteLock);
     increment_thread2_cmd(&control, api_name);
 
-    test_passed = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 1);
+    TEST_GET_VAR = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 1);
     if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for LockCount == 1", api_name);
         TEST_END();
@@ -150,7 +150,7 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     }
 
     ExReleaseReadWriteLock(&ReadWriteLock);
-    test_passed = timed_poll_for_value(&control.thread2_status, 2);
+    TEST_GET_VAR = timed_poll_for_value(&control.thread2_status, 2);
     if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for thread2_status == 2", api_name);
         TEST_END();
@@ -161,7 +161,7 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     ExAcquireReadWriteLockShared(&ReadWriteLock);
     increment_thread2_cmd(&control, api_name);
 
-    test_passed = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 1);
+    TEST_GET_VAR = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 1);
     if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for LockCount == 1", api_name);
         TEST_END();
@@ -179,7 +179,7 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
 
     increment_thread2_cmd(&control, api_name);
     ExReleaseReadWriteLock(&ReadWriteLock);
-    test_passed = timed_poll_for_value(&control.thread2_status, 4);
+    TEST_GET_VAR = timed_poll_for_value(&control.thread2_status, 4);
     if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for thread2_status == 4", api_name);
         TEST_END();
@@ -190,7 +190,7 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     ExAcquireReadWriteLockShared(&ReadWriteLock);
     increment_thread2_cmd(&control, api_name);
 
-    test_passed = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 1);
+    TEST_GET_VAR = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 1);
     if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for LockCount == 1", api_name);
         TEST_END();
@@ -205,7 +205,7 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
         return;
     }
 
-    test_passed = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 2);
+    TEST_GET_VAR = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 2);
     if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for LockCount == 2", api_name);
         TEST_END();
@@ -224,7 +224,7 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     for (BYTE i = 0; i < 10; i++) {
         TEST_FAILED(); // TODO: Why force fail here?
         if ((control.thread2_status == 6) && (control.thread3_status == 2)) {
-            test_passed = 1; // TODO: test_passed should not be used here.
+            TEST_GET_VAR = 1; // TODO: TEST_GET_VAR should not be used here.
             break;
         }
         Sleep(10);

--- a/src/tests/ex/ExAcquireReadWriteLockShared.c
+++ b/src/tests/ex/ExAcquireReadWriteLockShared.c
@@ -115,7 +115,6 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     // Avoid spinning forever in the loop below.
     if (TEST_IS_FAILED) {
         TEST_END();
-        return;
     }
     ExReleaseReadWriteLock(&ReadWriteLock);
 
@@ -128,7 +127,6 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
         print("  ERROR: Did not create thread2");
         TEST_FAILED();
         TEST_END();
-        return;
     }
 
     ExAcquireReadWriteLockExclusive(&ReadWriteLock);
@@ -138,7 +136,6 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for LockCount == 1", api_name);
         TEST_END();
-        return;
     }
     // Second thread attempted to acquire the exclusive lock, incrementing ReadersWaitingCount and waiting
     assert_ERWLOCK_equals(&ReadWriteLock, 1, 0, 1, 0);
@@ -146,7 +143,6 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
         TEST_FAILED();
         print("  ERROR: The second thread was not supposed to write before the lock is released on the first thread.");
         TEST_END();
-        return;
     }
 
     ExReleaseReadWriteLock(&ReadWriteLock);
@@ -154,7 +150,6 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for thread2_status == 2", api_name);
         TEST_END();
-        return;
     }
 
     // Test case where LockCount != 0, ReaderEntryCount != 0, and WritersWaitingCount == 0. Should grab lock fine.
@@ -165,7 +160,6 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for LockCount == 1", api_name);
         TEST_END();
-        return;
     }
     // Second thread attempted to acquire the shared lock, incrementing ReaderEntryCount and getting the lock
     assert_ERWLOCK_equals(&ReadWriteLock, 1, 0, 0, 2);
@@ -174,7 +168,6 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
         TEST_FAILED();
         print("  ERROR: The second thread was supposed to obtain the shared lock and update thread2_status.");
         TEST_END();
-        return;
     }
 
     increment_thread2_cmd(&control, api_name);
@@ -183,7 +176,6 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for thread2_status == 4", api_name);
         TEST_END();
-        return;
     }
 
     // Test case where LockCount != 0, ReaderEntryCount != 0, and WritersWaitingCount != 0. Should wait for exclusive thread to release.
@@ -194,7 +186,6 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for LockCount == 1", api_name);
         TEST_END();
-        return;
     }
 
     HANDLE handle_thread3;
@@ -202,21 +193,18 @@ TEST_FUNC(ExAcquireReadWriteLockShared)
     if (result != STATUS_SUCCESS) {
         TEST_FAILED();
         TEST_END();
-        return;
     }
 
     TEST_GET_VAR = timed_poll_for_value((ULONG*)&ReadWriteLock.LockCount, 2);
     if (TEST_IS_FAILED) {
         print("  ERROR: %s failed waiting for LockCount == 2", api_name);
         TEST_END();
-        return;
     }
     // Third thread attempted to acquire the shared lock but there is already another exclusive request in flight.
     assert_ERWLOCK_equals(&ReadWriteLock, 2, 1, 1, 1);
     if (control.thread3_status == 1) {
         TEST_FAILED();
         TEST_END();
-        return;
     }
     ExReleaseReadWriteLock(&ReadWriteLock);
 

--- a/src/tests/ke/suite/thread.c
+++ b/src/tests/ke/suite/thread.c
@@ -9,8 +9,7 @@
 #include "util/exception.h"
 #include "assertions/defines.h"
 
-// TODO: Add below into nxdk's xboxkrnl/ntstatus.h file
-#define STATUS_SUSPEND_COUNT_EXCEEDED 0xC000004A
+#include "util/nxdk_patch.h" // TODO: Remove this line once STATUS_SUSPEND_COUNT_EXCEEDED is upstream.
 
 typedef struct {
     BOOL terminate;

--- a/src/tests/ke/suite/thread.c
+++ b/src/tests/ke/suite/thread.c
@@ -110,7 +110,7 @@ static BOOL KeResumeSuspendThreadInline(const char* test_name, BOOL suspend, thr
 
     HANDLE hThread = CreateThread(NULL, 0, KeResumeSuspendThread_sync, (void*)&thread_data, (suspend ? CREATE_SUSPENDED : 0), NULL);
     GEN_CHECK(hThread != NULL, TRUE, "valid handle");
-    if(!hThread) {
+    if (!hThread) {
         print("  ERROR: Did not create thread");
         TEST_FAILED();
         THREAD_DUO_EVENTS_DESTROY(hEventMain, hEventThread);

--- a/src/tests/nt/NtReadFile.c
+++ b/src/tests/nt/NtReadFile.c
@@ -38,7 +38,6 @@ TEST_FUNC(NtReadFile)
         NtClose(handle);
         TEST_FAILED();
         TEST_END();
-        return;
     }
 
     status = NtReadFile(handle,

--- a/src/tests/nt/suite/thread.c
+++ b/src/tests/nt/suite/thread.c
@@ -81,7 +81,7 @@ static BOOL NtResumeSuspendThreadInline(const char* test_name, BOOL suspend, thr
 
     HANDLE hThread = CreateThread(NULL, 0, NtResumeSuspendThread_sync, (void*)&thread_data, (suspend ? CREATE_SUSPENDED : 0), NULL);
     GEN_CHECK(hThread != NULL, TRUE, "valid handle");
-    if(!hThread) {
+    if (!hThread) {
         print("  ERROR: Did not create thread");
         TEST_FAILED();
         THREAD_DUO_EVENTS_DESTROY(hEventMain, hEventThread);

--- a/src/tests/nt/suite/thread.c
+++ b/src/tests/nt/suite/thread.c
@@ -8,8 +8,7 @@
 #include "util/exception.h"
 #include "assertions/defines.h"
 
-// TODO: Add below into nxdk's xboxkrnl/ntstatus.h file
-#define STATUS_SUSPEND_COUNT_EXCEEDED 0xC000004A
+#include "util/nxdk_patch.h" // TODO: Remove this line once STATUS_SUSPEND_COUNT_EXCEEDED is upstream.
 
 typedef struct {
     BOOL terminate;

--- a/src/tests/rtl/RtlCopyString.c
+++ b/src/tests/rtl/RtlCopyString.c
@@ -16,7 +16,7 @@ TEST_FUNC(RtlCopyString)
     RtlInitAnsiString(&dst_str, dst_char_arr);
     RtlCopyString(&dst_str, &src_str);
 
-    if(strncmp(src_str.Buffer, dst_char_arr, src_str.Length) != 0) {
+    if (strncmp(src_str.Buffer, dst_char_arr, src_str.Length) != 0) {
         TEST_FAILED();
     }
 

--- a/src/tests/rtl/RtlMoveMemory.c
+++ b/src/tests/rtl/RtlMoveMemory.c
@@ -12,24 +12,24 @@ TEST_FUNC(RtlMoveMemory)
     char rnd_letter;
     /* CREATE AND FILL THE SOURCE BUFFER */
     CHAR* src_buffer = malloc(sizeof(CHAR) * size);
-    if(src_buffer == NULL) {
+    if (src_buffer == NULL) {
         print("ERROR: Could not malloc src_buffer");
     }
     srand(seed);
-    for(int k=0; k<size; k++){
+    for (int k=0; k<size; k++) {
         rnd_letter = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"[rand() % 26];
         src_buffer[k] = rnd_letter;
     }
 
     /* CREATE AND FILL THE DESTINATION BUFFER (using RtlMoveMemory)*/
     CHAR* dest_buffer = malloc(sizeof(CHAR) * size);
-    if(dest_buffer == NULL) {
+    if (dest_buffer == NULL) {
         print("ERROR: Could not malloc dest_buffer");
     }
     RtlMoveMemory(dest_buffer, (void*)src_buffer, size);
 
-    for(int k=0; k<size; k++){
-        if(src_buffer[k] != dest_buffer[k]){
+    for (int k=0; k<size; k++) {
+        if (src_buffer[k] != dest_buffer[k]) {
             TEST_FAILED();
             break;
         }

--- a/src/tests/rtl/RtlZeroMemory.c
+++ b/src/tests/rtl/RtlZeroMemory.c
@@ -9,12 +9,12 @@ TEST_FUNC(RtlZeroMemory)
 
     const int size = 1024;
     CHAR* alloc_buffer = malloc(sizeof(CHAR) * size);
-    if(alloc_buffer == NULL) {
+    if (alloc_buffer == NULL) {
         print("ERROR: Could not malloc alloc_buffer");
     }
     RtlZeroMemory(alloc_buffer, size);
-    for(int k=0; k<size; k++){
-        if(alloc_buffer[k] != (char)0){
+    for (int k=0; k<size; k++) {
+        if (alloc_buffer[k] != (char)0) {
             TEST_FAILED();
             break;
         }

--- a/src/tests/rtl/suite/call_trace.c
+++ b/src/tests/rtl/suite/call_trace.c
@@ -78,7 +78,8 @@ TEST_FUNC(RtlCaptureStackBackTrace)
     TEST_END();
 }
 
-void stub_RtlGetCallersAddress(PVOID* CallerAddress_test, PVOID* CallersCaller_test, PULONG CallerAddress_expected){
+void stub_RtlGetCallersAddress(PVOID* CallerAddress_test, PVOID* CallersCaller_test, PULONG CallerAddress_expected)
+{
     *CallerAddress_expected = (ULONG)__builtin_return_address(0);
     RtlGetCallersAddress(CallerAddress_test, CallersCaller_test);
 }

--- a/src/tests/rtl/suite/string_conversion.c
+++ b/src/tests/rtl/suite/string_conversion.c
@@ -18,7 +18,7 @@ TEST_FUNC(RtlAnsiStringToUnicodeString)
     UNICODE_STRING dest_str = { 0 };
     ANSI_STRING src_str = { 0 };
     CHAR* long_str = malloc(sizeof(CHAR) * long_str_size);
-    if(long_str == NULL) {
+    if (long_str == NULL) {
         print("ERROR: Could not malloc long_str");
     }
 

--- a/src/util/device_dummy.c
+++ b/src/util/device_dummy.c
@@ -15,19 +15,19 @@ DRIVER_OBJECT dummy_driver_object = {
     .DriverDeleteDevice = NULL,
     .DriverDismountVolume = NULL,
     .MajorFunction = {
-        IoInvalidDeviceRequest, // IRP_MJ_CREATE
-        IoInvalidDeviceRequest, // IRP_MJ_CLOSE
-        IoInvalidDeviceRequest, // IRP_MJ_READ
-        IoInvalidDeviceRequest, // IRP_MJ_WRITE
-        IoInvalidDeviceRequest, // IRP_MJ_QUERY_INFORMATION
-        IoInvalidDeviceRequest, // IRP_MJ_SET_INFORMATION
-        IoInvalidDeviceRequest, // IRP_MJ_FLUSH_BUFFERS
-        IoInvalidDeviceRequest, // IRP_MJ_QUERY_VOLUME_INFORMATION
-        IoInvalidDeviceRequest, // IRP_MJ_DIRECTORY_CONTROL
-        IoInvalidDeviceRequest, // IRP_MJ_FILE_SYSTEM_CONTROL
-        IoInvalidDeviceRequest, // IRP_MJ_DEVICE_CONTROL
-        IoInvalidDeviceRequest, // IRP_MJ_INTERNAL_DEVICE_CONTROL
-        IoInvalidDeviceRequest, // IRP_MJ_SHUTDOWN
-        IoInvalidDeviceRequest  // IRP_MJ_CLEANUP
+        IoInvalidDeviceRequest, // 0x00 = IRP_MJ_CREATE
+        IoInvalidDeviceRequest, // 0x01 = IRP_MJ_CLOSE
+        IoInvalidDeviceRequest, // 0x02 = IRP_MJ_READ
+        IoInvalidDeviceRequest, // 0x03 = IRP_MJ_WRITE
+        IoInvalidDeviceRequest, // 0x04 = IRP_MJ_QUERY_INFORMATION
+        IoInvalidDeviceRequest, // 0x05 = IRP_MJ_SET_INFORMATION
+        IoInvalidDeviceRequest, // 0x06 = IRP_MJ_FLUSH_BUFFERS
+        IoInvalidDeviceRequest, // 0x07 = IRP_MJ_QUERY_VOLUME_INFORMATION
+        IoInvalidDeviceRequest, // 0x08 = IRP_MJ_DIRECTORY_CONTROL
+        IoInvalidDeviceRequest, // 0x09 = IRP_MJ_FILE_SYSTEM_CONTROL
+        IoInvalidDeviceRequest, // 0x0A = IRP_MJ_DEVICE_CONTROL
+        IoInvalidDeviceRequest, // 0x0B = IRP_MJ_INTERNAL_DEVICE_CONTROL
+        IoInvalidDeviceRequest, // 0x0C = IRP_MJ_SHUTDOWN
+        IoInvalidDeviceRequest  // 0x0D = IRP_MJ_CLEANUP
     }
 };

--- a/src/util/nxdk_patch.h
+++ b/src/util/nxdk_patch.h
@@ -1,0 +1,13 @@
+#pragma once
+
+// Place missing nxdk implementations here to make them easy to track.
+// TODO: Upstream this file's contents to the nxdk repo in a future pull request.
+// Include this header in your test files for the time being.
+// This file cannot be removed until all of the tests are fully implemented.
+
+#ifndef STATUS_SUSPEND_COUNT_EXCEEDED
+// TODO: Add below into nxdk's xboxkrnl/ntstatus.h file
+#define STATUS_SUSPEND_COUNT_EXCEEDED 0xC000004A
+#else
+#warning "STATUS_SUSPEND_COUNT_EXCEEDED has been upstreamed; patch can be safely removed."
+#endif

--- a/src/util/output.c
+++ b/src/util/output.c
@@ -52,9 +52,13 @@ void print_test_header(
 void print_test_footer(
     int api_num,
     const char* api_name,
-    BOOL tests_passed)
+    BOOL tests_passed,
+    const char* reason)
 {
-    if(tests_passed) {
+    if(reason) {
+        print("%03u - %s: SKIPPED - %s", api_num, api_name, reason);
+    }
+    else if(tests_passed) {
         print("%03u - %s: All tests PASSED", api_num, api_name);
     }
     else {

--- a/src/util/output.c
+++ b/src/util/output.c
@@ -55,10 +55,10 @@ void print_test_footer(
     BOOL tests_passed,
     const char* reason)
 {
-    if(reason) {
+    if (reason) {
         print("%03u - %s: SKIPPED - %s", api_num, api_name, reason);
     }
-    else if(tests_passed) {
+    else if (tests_passed) {
         print("%03u - %s: All tests PASSED", api_num, api_name);
     }
     else {
@@ -93,10 +93,10 @@ int write_to_output_file(
         &bytes_written,
         NULL
     );
-    if(!ret && output_video) {
+    if (!ret && output_video) {
         debugPrint("ERROR: Could not write to output file\n");
     }
-    if(bytes_written != num_bytes_to_print) {
+    if (bytes_written != num_bytes_to_print) {
         if (output_video) {
             debugPrint("ERROR: Bytes written = %lu, bytes expected to write = %lu\n",
                        bytes_written, num_bytes_to_print);
@@ -109,7 +109,7 @@ int write_to_output_file(
 void close_output_file()
 {
     BOOL ret = CloseHandle(output_filehandle);
-    if(!ret) {
+    if (!ret) {
         print("ERROR: Could not close output file");
     }
 }

--- a/src/util/output.h
+++ b/src/util/output.h
@@ -17,7 +17,6 @@ void print_test_footer(int, const char*, BOOL, const char*);
 #define TEST_END() TEST_END_EX(NULL)
 #define TEST_SKIP_OPT(reason) print("  SKIP(line %d): %s", __LINE__, reason)
 #define TEST_SKIP_END(reason) TEST_END_EX(reason)
-#define TEST_UNIMPLEMENTED()
 #define TEST_FAILED() TEST_GET_VAR = 0
 #define TEST_IS_FAILED (!TEST_GET_VAR)
 #define TEST_IS_SUCCESS (TEST_GET_VAR)

--- a/src/util/output.h
+++ b/src/util/output.h
@@ -12,7 +12,8 @@ void print_test_footer(int, const char*, BOOL);
 #define TEST_GET_API_NAME api_name
 #define TEST_BEGIN() print_test_header(api_num, api_name); \
     BOOL TEST_GET_VAR = 1
-#define TEST_END() print_test_footer(api_num, api_name, test_passed)
+#define TEST_END() print_test_footer(api_num, api_name, test_passed); \
+    return
 #define TEST_UNIMPLEMENTED()
 #define TEST_FAILED() TEST_GET_VAR = 0
 #define TEST_IS_FAILED (!TEST_GET_VAR)

--- a/src/util/output.h
+++ b/src/util/output.h
@@ -4,7 +4,7 @@
 
 void print(const char* str, ...);
 void print_test_header(int, const char*);
-void print_test_footer(int, const char*, BOOL);
+void print_test_footer(int, const char*, BOOL, const char*);
 
 #define TEST_FUNC(name) void test_ ## name(int api_num, const char* api_name)
 #define TEST_GET_VAR test_passed
@@ -12,8 +12,11 @@ void print_test_footer(int, const char*, BOOL);
 #define TEST_GET_API_NAME api_name
 #define TEST_BEGIN() print_test_header(api_num, api_name); \
     BOOL TEST_GET_VAR = 1
-#define TEST_END() print_test_footer(api_num, api_name, test_passed); \
+#define TEST_END_EX(reason) print_test_footer(api_num, api_name, test_passed, reason); \
     return
+#define TEST_END() TEST_END_EX(NULL)
+#define TEST_SKIP_OPT(reason) print("  SKIP(line %d): %s", __LINE__, reason)
+#define TEST_SKIP_END(reason) TEST_END_EX(reason)
 #define TEST_UNIMPLEMENTED()
 #define TEST_FAILED() TEST_GET_VAR = 0
 #define TEST_IS_FAILED (!TEST_GET_VAR)


### PR DESCRIPTION
Some modifications have been made to either improve the code or add planned feature support.

- Add `TEST_SKIP_OPT` and `TEST_SKIP_END` macros for future feature support.
  - `TEST_SKIP_OPT` is intended for scenarios where a portion of the tests cannot be executed due to certain conditions.
  - `TEST_SKIP_END` is intended for scenarios where entire tests cannot be executed under certain conditions, such as when a retail kernel does not export every symbol while a dev/debug kit does.
- Add an `nxdk_patch` header file for changes that need to be upstreamed. It is best to document what is missing from the nxdk repository here, then submit pull requests upstream to update the nxdk repository.
- Improve the `TEST_END` macro by integrating a return statement, removing the need for redundant return statements in individual tests.
- Improve the `Makefile` by:
  - Scanning the `.c` files only once instead of repeatedly scanning for every file compilation.
  - Fetching the Git version once rather than during every single file compilation.
  - Setting the compilation flags once so they do not repeat for every file compilation.
  - Minor formatting adjustments for better readability.
- Fix various coding format mistakes discovered along the way.
- Pulled a couple of PatrickvL's commits from #112 pull request:
  - Cherry-picked `update device dummy comment`.
  - Cherry-picked modified `macro argument parenthesization`.